### PR TITLE
Pet Health MVP: Vaccinations UI CRUD, date defaults, readable dates, remove/deceased dialog, 403 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here, following the [Keep a C
 
 ## [Unreleased]
 
+### Added
+- Frontend (Pet Health): Vaccinations section with full owner-only CRUD, capability-gated, validation, and tests.
+- Frontend (Pet Health): Default dates in forms — weight and medical note dates default to today; vaccination administered_at defaults to today and due_at defaults to one year from today.
+
+### Changed
+- Frontend (Pet Health): Human‑readable date display for health records (weights, medical notes, vaccinations) using locale formatting instead of raw ISO strings.
+- Frontend: Restored Remove/status change flow in Pet Details with dialog (lost/deceased), password confirmation, and toasts; refreshes profile on success.
+
+### Fixed
+- Frontend (Pet Profile): Resolved 403 on update by converting ISO dates to `YYYY-MM-DD` for HTML date inputs.
+- Frontend: Removed duplicate Edit button from owner actions.
+- Frontend: Repaired regressions in `WeightForm.tsx` and `PetProfilePage.tsx` introduced during earlier edits.
+
 ### Changed
 - **Docs**: Updated `GEMINI.md` with a new "Linting and Formatting" section.
 - **Backend**: Ran `pint` to fix PHP code style issues.

--- a/backend/app/Console/Commands/SendVaccinationReminders.php
+++ b/backend/app/Console/Commands/SendVaccinationReminders.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\NotificationType;
+use App\Models\Pet;
+use App\Models\User;
+use App\Models\VaccinationRecord;
+use App\Services\NotificationService;
+use App\Services\PetCapabilityService;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class SendVaccinationReminders extends Command
+{
+    protected $signature = 'reminders:vaccinations {--days=3 : How many days ahead to look for due vaccinations}';
+
+    protected $description = 'Send vaccination due reminders to pet owners and mark records to avoid duplicate reminders';
+
+    public function handle(): int
+    {
+        $days = (int) $this->option('days');
+        $today = Carbon::today();
+        $cutoff = $today->copy()->addDays($days);
+
+        $this->info("Scanning for vaccinations due between {$today->toDateString()} and {$cutoff->toDateString()}...");
+
+        $query = VaccinationRecord::query()
+            ->whereNotNull('due_at')
+            ->whereDate('due_at', '<=', $cutoff)
+            ->whereNull('reminder_sent_at')
+            ->with(['pet' => function ($q) {
+                $q->with('user', 'petType');
+            }]);
+
+        $count = 0;
+        $service = app(NotificationService::class);
+
+        $query->chunkById(100, function ($records) use (&$count, $service, $today) {
+            foreach ($records as $record) {
+                $pet = $record->pet;
+                if (! $pet || ! $pet->user) {
+                    continue;
+                }
+
+                // Ensure capability allows vaccinations for this pet
+                try {
+                    PetCapabilityService::ensure($pet, 'vaccinations');
+                } catch (\Throwable $e) {
+                    continue;
+                }
+
+                $owner = $pet->user;
+
+                $data = [
+                    'message' => sprintf(
+                        'Reminder: %s is due for %s on %s',
+                        $pet->name,
+                        $record->vaccine_name,
+                        optional($record->due_at)->toDateString()
+                    ),
+                    'link' => url('/pets/'.$pet->id.'#vaccinations'),
+                    'pet_id' => $pet->id,
+                    'vaccination_record_id' => $record->id,
+                    'vaccine_name' => $record->vaccine_name,
+                    'due_at' => optional($record->due_at)?->toDateString(),
+                    'notes' => $record->notes,
+                ];
+
+                // Respect user preferences via NotificationService
+                $service->send($owner, NotificationType::VACCINATION_REMINDER->value, $data);
+
+                // Mark reminder_sent_at to avoid duplicates (idempotent if run again today)
+                $record->update(['reminder_sent_at' => now()]);
+
+                $count++;
+            }
+        });
+
+        $this->info("Sent {$count} vaccination reminder(s).");
+        Log::info('Vaccination reminder job completed', ['count' => $count]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/app/Enums/NotificationType.php
+++ b/backend/app/Enums/NotificationType.php
@@ -10,6 +10,7 @@ enum NotificationType: string
     case HELPER_RESPONSE_REJECTED = 'helper_response_rejected';
     case FOSTER_ASSIGNMENT_COMPLETED = 'foster_assignment_completed';
     case FOSTER_ASSIGNMENT_CANCELED = 'foster_assignment_canceled';
+    case VACCINATION_REMINDER = 'vaccination_reminder';
 
     public function getGroup(): string
     {
@@ -20,6 +21,7 @@ enum NotificationType: string
             self::HELPER_RESPONSE_REJECTED,
             self::FOSTER_ASSIGNMENT_COMPLETED,
             self::FOSTER_ASSIGNMENT_CANCELED => 'helper_profile',
+            self::VACCINATION_REMINDER => 'pet_health',
         };
     }
 
@@ -32,6 +34,7 @@ enum NotificationType: string
             self::HELPER_RESPONSE_REJECTED => 'Helper Response Rejected',
             self::FOSTER_ASSIGNMENT_COMPLETED => 'Foster Assignment Completed',
             self::FOSTER_ASSIGNMENT_CANCELED => 'Foster Assignment Canceled',
+            self::VACCINATION_REMINDER => 'Vaccination Due Soon',
         };
     }
 }

--- a/backend/app/Filament/Widgets/EmailSystemAlertsWidget.php
+++ b/backend/app/Filament/Widgets/EmailSystemAlertsWidget.php
@@ -78,7 +78,9 @@ class EmailSystemAlertsWidget extends Widget
         try {
             $stuckJobs = DB::table('jobs')
                 ->where('payload', 'like', '%SendNotificationEmail%')
-                ->where('created_at', '<', now()->subHours(2))
+                // jobs.created_at is stored as an integer (Unix timestamp)
+                // so compare using a Unix timestamp to avoid type errors on PostgreSQL
+                ->where('created_at', '<', now()->subHours(2)->timestamp)
                 ->count();
 
             if ($stuckJobs > 0) {

--- a/backend/app/Http/Controllers/MedicalNoteController.php
+++ b/backend/app/Http/Controllers/MedicalNoteController.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MedicalNote;
+use App\Models\Pet;
+use App\Traits\ApiResponseTrait;
+use App\Services\PetCapabilityService;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use OpenApi\Annotations as OA;
+
+class MedicalNoteController extends Controller
+{
+    use ApiResponseTrait;
+
+    /**
+     * @OA\Schema(
+     *     schema="MedicalNote",
+     *     title="MedicalNote",
+     *     description="Medical note model",
+     *     @OA\Property(property="id", type="integer", format="int64"),
+     *     @OA\Property(property="pet_id", type="integer", format="int64"),
+     *     @OA\Property(property="note", type="string"),
+     *     @OA\Property(property="record_date", type="string", format="date"),
+     *     @OA\Property(property="created_at", type="string", format="date-time"),
+     *     @OA\Property(property="updated_at", type="string", format="date-time")
+     * )
+     */
+
+    /**
+     * @OA\Get(
+     *     path="/api/pets/{pet}/medical-notes",
+     *     summary="List medical notes for a pet",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="page", in="query", required=false, @OA\Schema(type="integer")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of medical notes",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/MedicalNote")),
+     *                 @OA\Property(property="links", type="object"),
+     *                 @OA\Property(property="meta", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden")
+     * )
+     */
+    public function index(Request $request, Pet $pet)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+
+        // For now, reuse 'medical' capability as the gate for notes
+        PetCapabilityService::ensure($pet, 'medical');
+
+        $items = $pet->medicalNotes()->orderByDesc('record_date')->paginate(25);
+        $payload = [
+            'data' => $items->items(),
+            'links' => [
+                'first' => $items->url(1),
+                'last' => $items->url($items->lastPage()),
+                'prev' => $items->previousPageUrl(),
+                'next' => $items->nextPageUrl(),
+            ],
+            'meta' => [
+                'current_page' => $items->currentPage(),
+                'from' => $items->firstItem(),
+                'last_page' => $items->lastPage(),
+                'path' => $items->path(),
+                'per_page' => $items->perPage(),
+                'to' => $items->lastItem(),
+                'total' => $items->total(),
+            ],
+        ];
+
+        return response()->json(['data' => $payload]);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/pets/{pet}/medical-notes",
+     *     summary="Create a medical note",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         required={"note","record_date"},
+     *         @OA\Property(property="note", type="string", example="Rabies vaccination"),
+     *         @OA\Property(property="record_date", type="string", format="date", example="2024-06-01")
+     *     )),
+     *     @OA\Response(response=201, description="Created", @OA\JsonContent(@OA\Property(property="data", ref="#/components/schemas/MedicalNote"))),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function store(Request $request, Pet $pet)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+
+        PetCapabilityService::ensure($pet, 'medical');
+
+        $validated = $request->validate([
+            'note' => 'required|string',
+            'record_date' => 'required|date',
+        ]);
+
+        // Enforce per-pet uniqueness by date
+        if ($pet->medicalNotes()->whereDate('record_date', $validated['record_date'])->exists()) {
+            throw ValidationException::withMessages([
+                'record_date' => ['The record date has already been taken for this pet.'],
+            ]);
+        }
+
+        $created = $pet->medicalNotes()->create($validated);
+        return $this->sendSuccess($created, 201);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/pets/{pet}/medical-notes/{note}",
+     *     summary="Get a single medical note",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="note", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="OK", @OA\JsonContent(@OA\Property(property="data", ref="#/components/schemas/MedicalNote"))),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
+    public function show(Request $request, Pet $pet, MedicalNote $note)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+        PetCapabilityService::ensure($pet, 'medical');
+
+        if ($note->pet_id !== $pet->id) return $this->sendError('Not found.', 404);
+        return $this->sendSuccess($note);
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/api/pets/{pet}/medical-notes/{note}",
+     *     summary="Update a medical note",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="note", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         @OA\Property(property="note", type="string"),
+     *         @OA\Property(property="record_date", type="string", format="date")
+     *     )),
+     *     @OA\Response(response=200, description="OK", @OA\JsonContent(@OA\Property(property="data", ref="#/components/schemas/MedicalNote"))),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Not found"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function update(Request $request, Pet $pet, MedicalNote $note)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+        PetCapabilityService::ensure($pet, 'medical');
+        if ($note->pet_id !== $pet->id) return $this->sendError('Not found.', 404);
+
+        $validated = $request->validate([
+            'note' => 'sometimes|string',
+            'record_date' => 'sometimes|date',
+        ]);
+
+        if (array_key_exists('record_date', $validated)) {
+            $exists = $pet->medicalNotes()
+                ->where('id', '!=', $note->id)
+                ->whereDate('record_date', $validated['record_date'])
+                ->exists();
+            if ($exists) {
+                throw ValidationException::withMessages([
+                    'record_date' => ['The record date has already been taken for this pet.'],
+                ]);
+            }
+        }
+
+        $note->update($validated);
+        return $this->sendSuccess($note);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/api/pets/{pet}/medical-notes/{note}",
+     *     summary="Delete a medical note",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="note", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Deleted", @OA\JsonContent(@OA\Property(property="data", type="boolean", example=true))),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
+    public function destroy(Request $request, Pet $pet, MedicalNote $note)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+        PetCapabilityService::ensure($pet, 'medical');
+        if ($note->pet_id !== $pet->id) return $this->sendError('Not found.', 404);
+        $note->delete();
+        return response()->json(['data' => true]);
+    }
+}

--- a/backend/app/Http/Controllers/VaccinationRecordController.php
+++ b/backend/app/Http/Controllers/VaccinationRecordController.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\VaccinationRecord;
+use App\Models\Pet;
+use App\Traits\ApiResponseTrait;
+use App\Services\PetCapabilityService;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use OpenApi\Annotations as OA;
+
+class VaccinationRecordController extends Controller
+{
+    use ApiResponseTrait;
+
+    /**
+     * @OA\Schema(
+     *     schema="VaccinationRecord",
+     *     title="VaccinationRecord",
+     *     description="Vaccination record model",
+     *     @OA\Property(property="id", type="integer", format="int64"),
+     *     @OA\Property(property="pet_id", type="integer", format="int64"),
+     *     @OA\Property(property="vaccine_name", type="string"),
+     *     @OA\Property(property="administered_at", type="string", format="date"),
+     *     @OA\Property(property="due_at", type="string", format="date"),
+     *     @OA\Property(property="notes", type="string"),
+     *     @OA\Property(property="reminder_sent_at", type="string", format="date-time"),
+     *     @OA\Property(property="created_at", type="string", format="date-time"),
+     *     @OA\Property(property="updated_at", type="string", format="date-time")
+     * )
+     */
+
+    /**
+     * @OA\Get(
+     *     path="/api/pets/{pet}/vaccinations",
+     *     summary="List vaccination records for a pet",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="page", in="query", required=false, @OA\Schema(type="integer")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of vaccination records",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/VaccinationRecord")),
+     *                 @OA\Property(property="links", type="object"),
+     *                 @OA\Property(property="meta", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden")
+     * )
+     */
+    public function index(Request $request, Pet $pet)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+
+        PetCapabilityService::ensure($pet, 'vaccinations');
+
+        $items = $pet->vaccinations()->orderByDesc('administered_at')->paginate(25);
+        $payload = [
+            'data' => $items->items(),
+            'links' => [
+                'first' => $items->url(1),
+                'last' => $items->url($items->lastPage()),
+                'prev' => $items->previousPageUrl(),
+                'next' => $items->nextPageUrl(),
+            ],
+            'meta' => [
+                'current_page' => $items->currentPage(),
+                'from' => $items->firstItem(),
+                'last_page' => $items->lastPage(),
+                'path' => $items->path(),
+                'per_page' => $items->perPage(),
+                'to' => $items->lastItem(),
+                'total' => $items->total(),
+            ],
+        ];
+
+        return response()->json(['data' => $payload]);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/pets/{pet}/vaccinations",
+     *     summary="Create a vaccination record",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         required={"vaccine_name","administered_at"},
+     *         @OA\Property(property="vaccine_name", type="string", example="Rabies"),
+     *         @OA\Property(property="administered_at", type="string", format="date", example="2024-06-01"),
+     *         @OA\Property(property="due_at", type="string", format="date", example="2025-06-01"),
+     *         @OA\Property(property="notes", type="string", example="Booster due next year"),
+     *     )),
+     *     @OA\Response(response=201, description="Created", @OA\JsonContent(@OA\Property(property="data", ref="#/components/schemas/VaccinationRecord"))),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function store(Request $request, Pet $pet)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+
+        PetCapabilityService::ensure($pet, 'vaccinations');
+
+        $validated = $request->validate([
+            'vaccine_name' => 'required|string',
+            'administered_at' => 'required|date',
+            'due_at' => 'nullable|date|after_or_equal:administered_at',
+            'notes' => 'nullable|string',
+        ]);
+
+        // Uniqueness per pet: vaccine_name + administered_at
+        $exists = $pet->vaccinations()
+            ->where('vaccine_name', $validated['vaccine_name'])
+            ->whereDate('administered_at', $validated['administered_at'])
+            ->exists();
+        if ($exists) {
+            throw ValidationException::withMessages([
+                'administered_at' => ['This vaccination already exists for this date.'],
+            ]);
+        }
+
+        $created = $pet->vaccinations()->create($validated);
+        return $this->sendSuccess($created, 201);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/pets/{pet}/vaccinations/{record}",
+     *     summary="Get a single vaccination record",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="record", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="OK", @OA\JsonContent(@OA\Property(property="data", ref="#/components/schemas/VaccinationRecord"))),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
+    public function show(Request $request, Pet $pet, VaccinationRecord $record)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+        PetCapabilityService::ensure($pet, 'vaccinations');
+
+        if ($record->pet_id !== $pet->id) return $this->sendError('Not found.', 404);
+        return $this->sendSuccess($record);
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/api/pets/{pet}/vaccinations/{record}",
+     *     summary="Update a vaccination record",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="record", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         @OA\Property(property="vaccine_name", type="string"),
+     *         @OA\Property(property="administered_at", type="string", format="date"),
+     *         @OA\Property(property="due_at", type="string", format="date"),
+     *         @OA\Property(property="notes", type="string")
+     *     )),
+     *     @OA\Response(response=200, description="OK", @OA\JsonContent(@OA\Property(property="data", ref="#/components/schemas/VaccinationRecord"))),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Not found"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function update(Request $request, Pet $pet, VaccinationRecord $record)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+        PetCapabilityService::ensure($pet, 'vaccinations');
+        if ($record->pet_id !== $pet->id) return $this->sendError('Not found.', 404);
+
+        $validated = $request->validate([
+            'vaccine_name' => 'sometimes|string',
+            'administered_at' => 'sometimes|date',
+            'due_at' => 'nullable|date|after_or_equal:administered_at',
+            'notes' => 'nullable|string',
+        ]);
+
+        // If administered_at or vaccine_name changes, enforce uniqueness
+        $name = $validated['vaccine_name'] ?? $record->vaccine_name;
+        $date = $validated['administered_at'] ?? $record->administered_at?->format('Y-m-d');
+        $exists = $pet->vaccinations()
+            ->where('id', '!=', $record->id)
+            ->where('vaccine_name', $name)
+            ->whereDate('administered_at', $date)
+            ->exists();
+        if ($exists) {
+            throw ValidationException::withMessages([
+                'administered_at' => ['This vaccination already exists for this date.'],
+            ]);
+        }
+
+        $record->update($validated);
+        return $this->sendSuccess($record);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/api/pets/{pet}/vaccinations/{record}",
+     *     summary="Delete a vaccination record",
+     *     tags={"Pets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="pet", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="record", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Deleted", @OA\JsonContent(@OA\Property(property="data", type="boolean", example=true))),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Not found")
+     * )
+     */
+    public function destroy(Request $request, Pet $pet, VaccinationRecord $record)
+    {
+        $user = $request->user();
+        if (! $user) return $this->sendError('Unauthenticated.', 401);
+        $isOwner = $user->id === $pet->user_id;
+        $isAdmin = method_exists($user, 'hasRole') && $user->hasRole(['admin', 'super_admin']);
+        if (! $isOwner && ! $isAdmin) return $this->sendError('Forbidden.', 403);
+        PetCapabilityService::ensure($pet, 'vaccinations');
+        if ($record->pet_id !== $pet->id) return $this->sendError('Not found.', 404);
+        $record->delete();
+        return response()->json(['data' => true]);
+    }
+}

--- a/backend/app/Jobs/SendNotificationEmail.php
+++ b/backend/app/Jobs/SendNotificationEmail.php
@@ -7,6 +7,7 @@ use App\Mail\HelperResponseAcceptedMail;
 use App\Mail\HelperResponseRejectedMail;
 use App\Mail\PlacementRequestAcceptedMail;
 use App\Mail\PlacementRequestResponseMail;
+use App\Mail\VaccinationReminderMail;
 use App\Models\EmailLog;
 use App\Models\Notification;
 use App\Models\User;
@@ -158,6 +159,7 @@ class SendNotificationEmail implements ShouldQueue
             NotificationType::PLACEMENT_REQUEST_ACCEPTED => new PlacementRequestAcceptedMail($this->user, $notificationType, $this->data),
             NotificationType::HELPER_RESPONSE_ACCEPTED => new HelperResponseAcceptedMail($this->user, $notificationType, $this->data),
             NotificationType::HELPER_RESPONSE_REJECTED => new HelperResponseRejectedMail($this->user, $notificationType, $this->data),
+            NotificationType::VACCINATION_REMINDER => new VaccinationReminderMail($this->user, $notificationType, $this->data),
             default => null,
         };
     }

--- a/backend/app/Mail/VaccinationReminderMail.php
+++ b/backend/app/Mail/VaccinationReminderMail.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Mail;
+
+use App\Enums\NotificationType;
+use App\Models\Pet;
+use App\Models\VaccinationRecord;
+
+class VaccinationReminderMail extends NotificationMail
+{
+    protected function getTemplate(): string
+    {
+        return 'emails.notifications.vaccination-reminder';
+    }
+
+    protected function getSubject(): string
+    {
+        $petName = 'your pet';
+        if (isset($this->data['pet_id'])) {
+            $pet = Pet::find($this->data['pet_id']);
+            if ($pet) {
+                $petName = $pet->name;
+            }
+        }
+
+        $vaccine = $this->data['vaccine_name'] ?? 'a vaccine';
+        $dueStr = isset($this->data['due_at']) ? (string) $this->data['due_at'] : 'soon';
+
+        return "Reminder: {$petName} is due for {$vaccine} {$dueStr}";
+    }
+}

--- a/backend/app/Models/MedicalNote.php
+++ b/backend/app/Models/MedicalNote.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class MedicalNote extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'pet_id',
+        'note',
+        'record_date',
+    ];
+
+    protected $casts = [
+        'record_date' => 'date',
+    ];
+
+    public function pet(): BelongsTo
+    {
+        return $this->belongsTo(Pet::class);
+    }
+}

--- a/backend/app/Models/Pet.php
+++ b/backend/app/Models/Pet.php
@@ -116,6 +116,22 @@ class Pet extends Model
     }
 
     /**
+     * Get medical notes for this pet
+     */
+    public function medicalNotes(): HasMany
+    {
+        return $this->hasMany(MedicalNote::class);
+    }
+
+    /**
+     * Get vaccination records for this pet
+     */
+    public function vaccinations(): HasMany
+    {
+        return $this->hasMany(VaccinationRecord::class);
+    }
+
+    /**
      * Get comments for this pet
      */
     public function comments(): HasMany

--- a/backend/app/Models/VaccinationRecord.php
+++ b/backend/app/Models/VaccinationRecord.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class VaccinationRecord extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'pet_id',
+        'vaccine_name',
+        'administered_at',
+        'due_at',
+        'notes',
+        'reminder_sent_at',
+    ];
+
+    protected $casts = [
+        'administered_at' => 'date',
+        'due_at' => 'date',
+        'reminder_sent_at' => 'datetime',
+    ];
+
+    public function pet(): BelongsTo
+    {
+        return $this->belongsTo(Pet::class);
+    }
+}

--- a/backend/app/OpenApi/Schemas/MedicalNoteSchema.php
+++ b/backend/app/OpenApi/Schemas/MedicalNoteSchema.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="MedicalNote",
+ *     title="MedicalNote",
+ *     description="Medical note model",
+ *     @OA\Property(property="id", type="integer", format="int64"),
+ *     @OA\Property(property="pet_id", type="integer", format="int64"),
+ *     @OA\Property(property="note", type="string"),
+ *     @OA\Property(property="record_date", type="string", format="date"),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ */
+class MedicalNoteSchema
+{
+    // This class exists solely for OpenAPI schema generation
+}

--- a/backend/app/OpenApi/Schemas/VaccinationRecordSchema.php
+++ b/backend/app/OpenApi/Schemas/VaccinationRecordSchema.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="VaccinationRecord",
+ *     title="VaccinationRecord",
+ *     description="Vaccination record model",
+ *     @OA\Property(property="id", type="integer", format="int64"),
+ *     @OA\Property(property="pet_id", type="integer", format="int64"),
+ *     @OA\Property(property="vaccine_name", type="string"),
+ *     @OA\Property(property="administered_at", type="string", format="date"),
+ *     @OA\Property(property="due_at", type="string", format="date"),
+ *     @OA\Property(property="notes", type="string"),
+ *     @OA\Property(property="reminder_sent_at", type="string", format="date-time"),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ */
+class VaccinationRecordSchema
+{
+    // Exists solely for OpenAPI schema generation
+}

--- a/backend/app/Services/PetCapabilityService.php
+++ b/backend/app/Services/PetCapabilityService.php
@@ -14,6 +14,7 @@ class PetCapabilityService
     private const CAPABILITIES = [
         'fostering' => ['cat'],
         'medical' => ['cat'],
+        'vaccinations' => ['cat'],
         'ownership' => ['cat'],
         // 'weight' is dynamic per pet type; handled specially below
         'comments' => ['cat'],

--- a/backend/database/factories/MedicalNoteFactory.php
+++ b/backend/database/factories/MedicalNoteFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MedicalNote;
+use App\Models\Pet;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\MedicalNote>
+ */
+class MedicalNoteFactory extends Factory
+{
+    protected $model = MedicalNote::class;
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'pet_id' => Pet::factory(),
+            'record_date' => $this->faker->dateTimeBetween('-3 years', 'now'),
+            'note' => $this->faker->sentence(12),
+        ];
+    }
+}

--- a/backend/database/factories/VaccinationRecordFactory.php
+++ b/backend/database/factories/VaccinationRecordFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Pet;
+use App\Models\VaccinationRecord;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\VaccinationRecord>
+ */
+class VaccinationRecordFactory extends Factory
+{
+    protected $model = VaccinationRecord::class;
+
+    public function definition(): array
+    {
+        $administered = $this->faker->dateTimeBetween('-2 years', '-1 month');
+        $due = (clone $administered)->modify('+1 year');
+
+        return [
+            'pet_id' => Pet::factory(),
+            'vaccine_name' => $this->faker->randomElement(['Rabies', 'FVRCP', 'FeLV']),
+            'administered_at' => $administered,
+            'due_at' => $due,
+            'notes' => $this->faker->optional()->sentence(8),
+            'reminder_sent_at' => null,
+        ];
+    }
+}

--- a/backend/database/migrations/2025_09_27_140000_create_medical_notes_table.php
+++ b/backend/database/migrations/2025_09_27_140000_create_medical_notes_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('medical_notes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pet_id')->constrained()->onDelete('cascade');
+            $table->date('record_date');
+            $table->text('note');
+            $table->timestamps();
+
+            $table->unique(['pet_id', 'record_date']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('medical_notes');
+    }
+};

--- a/backend/database/migrations/2025_09_27_170000_create_vaccination_records_table.php
+++ b/backend/database/migrations/2025_09_27_170000_create_vaccination_records_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vaccination_records', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pet_id')->constrained()->onDelete('cascade');
+            $table->string('vaccine_name');
+            $table->date('administered_at');
+            $table->date('due_at')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamp('reminder_sent_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['pet_id', 'vaccine_name', 'administered_at'], 'vaccination_unique_per_pet_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vaccination_records');
+    }
+};

--- a/backend/resources/views/emails/notifications/vaccination-reminder.blade.php
+++ b/backend/resources/views/emails/notifications/vaccination-reminder.blade.php
@@ -1,0 +1,33 @@
+@extends('emails.notifications.layout')
+
+@section('content')
+    <h1>Vaccination Reminder</h1>
+
+    <p>Hello {{ $user->name ?? 'there' }},</p>
+
+    @php
+        $petName = isset($pet) && $pet ? $pet->name : 'your pet';
+        $vaccine = $vaccine_name ?? 'a vaccine';
+        $dueDate = isset($due_at) ? (new \Carbon\Carbon($due_at))->toFormattedDateString() : null;
+    @endphp
+
+    <p>
+        This is a friendly reminder that {{ $petName }} is due for {{ $vaccine }}
+        @if($dueDate)
+            on {{ $dueDate }}.
+        @else
+            soon.
+        @endif
+    </p>
+
+    @if(!empty($notes))
+        <p><strong>Notes:</strong> {{ $notes }}</p>
+    @endif
+
+    <p>
+        You can view {{ $petName }}'s health records here:
+        <a href="{{ $actionUrl }}">Open Pet Profile</a>
+    </p>
+
+    <p>If you no longer wish to receive these reminders, you can manage your preferences here: <a href="{{ $unsubscribeUrl }}">Unsubscribe</a></p>
+@endsection

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\FosterAssignmentController;
 use App\Http\Controllers\FosterReturnHandoverController;
 use App\Http\Controllers\HelperProfileController;
 use App\Http\Controllers\MedicalRecordController;
+use App\Http\Controllers\MedicalNoteController;
 use App\Http\Controllers\MessageController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\NotificationPreferenceController;
@@ -19,6 +20,7 @@ use App\Http\Controllers\UnsubscribeController;
 use App\Http\Controllers\UserProfileController;
 use App\Http\Controllers\VersionController;
 use App\Http\Controllers\WeightHistoryController;
+use App\Http\Controllers\VaccinationRecordController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -78,6 +80,20 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/pets/{pet}/weights/{weight}', [WeightHistoryController::class, 'show'])->whereNumber('weight');
     Route::put('/pets/{pet}/weights/{weight}', [WeightHistoryController::class, 'update'])->whereNumber('weight');
     Route::delete('/pets/{pet}/weights/{weight}', [WeightHistoryController::class, 'destroy'])->whereNumber('weight');
+
+    // Medical Notes
+    Route::get('/pets/{pet}/medical-notes', [MedicalNoteController::class, 'index']);
+    Route::post('/pets/{pet}/medical-notes', [MedicalNoteController::class, 'store']);
+    Route::get('/pets/{pet}/medical-notes/{note}', [MedicalNoteController::class, 'show'])->whereNumber('note');
+    Route::put('/pets/{pet}/medical-notes/{note}', [MedicalNoteController::class, 'update'])->whereNumber('note');
+    Route::delete('/pets/{pet}/medical-notes/{note}', [MedicalNoteController::class, 'destroy'])->whereNumber('note');
+
+    // Vaccinations
+    Route::get('/pets/{pet}/vaccinations', [VaccinationRecordController::class, 'index']);
+    Route::post('/pets/{pet}/vaccinations', [VaccinationRecordController::class, 'store']);
+    Route::get('/pets/{pet}/vaccinations/{record}', [VaccinationRecordController::class, 'show'])->whereNumber('record');
+    Route::put('/pets/{pet}/vaccinations/{record}', [VaccinationRecordController::class, 'update'])->whereNumber('record');
+    Route::delete('/pets/{pet}/vaccinations/{record}', [VaccinationRecordController::class, 'destroy'])->whereNumber('record');
     Route::post('/transfer-requests', [TransferRequestController::class, 'store']);
     Route::post('/transfer-requests/{transferRequest}/accept', [TransferRequestController::class, 'accept']);
     Route::post('/transfer-requests/{transferRequest}/reject', [TransferRequestController::class, 'reject']);

--- a/backend/routes/console.php
+++ b/backend/routes/console.php
@@ -2,9 +2,15 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
 
 // Custom commands are auto-discovered via PSR-4 in app/Console/Commands
+
+// Schedule: vaccination reminders once daily at 09:00 server time
+Schedule::command('reminders:vaccinations --days=3')
+    ->dailyAt('09:00')
+    ->withoutOverlapping();

--- a/backend/storage/api-docs/api-docs.json
+++ b/backend/storage/api-docs/api-docs.json
@@ -713,6 +713,341 @@
                 }
             }
         },
+        "/api/pets/{pet}/medical-notes": {
+            "get": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "List medical notes for a pet",
+                "operationId": "27b7f997f94c313fd5c2e89357cff803",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of medical notes",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/MedicalNote"
+                                                    }
+                                                },
+                                                "links": {
+                                                    "type": "object"
+                                                },
+                                                "meta": {
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "Create a medical note",
+                "operationId": "ea121f48244010b3c76fcb99ae70f11c",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "note",
+                                    "record_date"
+                                ],
+                                "properties": {
+                                    "note": {
+                                        "type": "string",
+                                        "example": "Rabies vaccination"
+                                    },
+                                    "record_date": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "2024-06-01"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/MedicalNote"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/pets/{pet}/medical-notes/{note}": {
+            "get": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "Get a single medical note",
+                "operationId": "da54fc88f502bc061e3094508a576ffc",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "note",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/MedicalNote"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "Update a medical note",
+                "operationId": "efcfcc1116ef04207cbbb1a771659c20",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "note",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "note": {
+                                        "type": "string"
+                                    },
+                                    "record_date": {
+                                        "type": "string",
+                                        "format": "date"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/MedicalNote"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "Delete a medical note",
+                "operationId": "281dc16899d2916a1065b1ce3b06485b",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "note",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/messages": {
             "get": {
                 "tags": [
@@ -2853,6 +3188,357 @@
                 ]
             }
         },
+        "/api/pets/{pet}/vaccinations": {
+            "get": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "List vaccination records for a pet",
+                "operationId": "c882ee81ccb8467f98bdfdb34b73a91f",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of vaccination records",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/VaccinationRecord"
+                                                    }
+                                                },
+                                                "links": {
+                                                    "type": "object"
+                                                },
+                                                "meta": {
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "Create a vaccination record",
+                "operationId": "e46907c67459c8d1bb8d3d804d01f63d",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "vaccine_name",
+                                    "administered_at"
+                                ],
+                                "properties": {
+                                    "vaccine_name": {
+                                        "type": "string",
+                                        "example": "Rabies"
+                                    },
+                                    "administered_at": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "2024-06-01"
+                                    },
+                                    "due_at": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "example": "2025-06-01"
+                                    },
+                                    "notes": {
+                                        "type": "string",
+                                        "example": "Booster due next year"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/VaccinationRecord"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/pets/{pet}/vaccinations/{record}": {
+            "get": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "Get a single vaccination record",
+                "operationId": "d829b531922efbd05d8134ddc600f54d",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "record",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/VaccinationRecord"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "Update a vaccination record",
+                "operationId": "1a0c4f5886641c12b6dcb48415f36baf",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "record",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "vaccine_name": {
+                                        "type": "string"
+                                    },
+                                    "administered_at": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "due_at": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "notes": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/VaccinationRecord"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Pets"
+                ],
+                "summary": "Delete a vaccination record",
+                "operationId": "1ae9bcad7bb2cc99608eefa565b24381",
+                "parameters": [
+                    {
+                        "name": "pet",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "record",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "boolean",
+                                            "example": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/version": {
             "get": {
                 "tags": [
@@ -3370,6 +4056,77 @@
                     }
                 },
                 "type": "object"
+            },
+            "MedicalNote": {
+                "title": "MedicalNote",
+                "description": "Medical note model",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "pet_id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "note": {
+                        "type": "string"
+                    },
+                    "record_date": {
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "VaccinationRecord": {
+                "title": "VaccinationRecord",
+                "description": "Vaccination record model",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "pet_id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "vaccine_name": {
+                        "type": "string"
+                    },
+                    "administered_at": {
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "due_at": {
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "notes": {
+                        "type": "string"
+                    },
+                    "reminder_sent_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
             }
         }
     },
@@ -3387,6 +4144,10 @@
             "description": "Helper Profiles"
         },
         {
+            "name": "Pets",
+            "description": "Pets"
+        },
+        {
             "name": "Messages",
             "description": "Messages"
         },
@@ -3397,10 +4158,6 @@
         {
             "name": "Notification Preferences",
             "description": "Notification Preferences"
-        },
-        {
-            "name": "Pets",
-            "description": "Pets"
         },
         {
             "name": "Pet Types",

--- a/backend/tests/Feature/MedicalNotesFeatureTest.php
+++ b/backend/tests/Feature/MedicalNotesFeatureTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Pet;
+use App\Models\PetType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+use Spatie\Permission\Models\Role;
+
+class MedicalNotesFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $owner;
+    protected User $otherUser;
+    protected PetType $catType;
+    protected PetType $dogType;
+    protected Pet $pet;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->owner = User::factory()->create();
+        $this->otherUser = User::factory()->create();
+
+        $this->catType = PetType::create([
+            'id' => 1,
+            'name' => 'Cat',
+            'slug' => 'cat',
+            'is_system' => true,
+            'display_order' => 1,
+        ]);
+
+        $this->dogType = PetType::create([
+            'id' => 2,
+            'name' => 'Dog',
+            'slug' => 'dog',
+            'is_system' => true,
+            'display_order' => 2,
+        ]);
+
+        $this->pet = Pet::factory()->create([
+            'user_id' => $this->owner->id,
+            'pet_type_id' => $this->catType->id,
+        ]);
+    }
+
+    public function test_owner_can_crud_medical_notes()
+    {
+        Sanctum::actingAs($this->owner);
+
+        // Create
+        $create = $this->postJson("/api/pets/{$this->pet->id}/medical-notes", [
+            'note' => 'Rabies vaccination administered',
+            'record_date' => '2024-06-01',
+        ]);
+        $create->assertStatus(201);
+        $id = $create->json('data.id');
+
+        // Index
+        $this->getJson("/api/pets/{$this->pet->id}/medical-notes")
+            ->assertOk()
+            ->assertJsonStructure(['data' => ['data', 'links', 'meta']]);
+
+        // Show
+        $this->getJson("/api/pets/{$this->pet->id}/medical-notes/{$id}")
+            ->assertOk()
+            ->assertJsonPath('data.id', $id);
+
+        // Update
+        $this->putJson("/api/pets/{$this->pet->id}/medical-notes/{$id}", [
+            'note' => 'Rabies vaccination administered - booster',
+        ])->assertOk()->assertJsonPath('data.note', 'Rabies vaccination administered - booster');
+
+        // Delete
+        $this->deleteJson("/api/pets/{$this->pet->id}/medical-notes/{$id}")
+            ->assertOk()->assertJson(['data' => true]);
+    }
+
+    public function test_non_owner_cannot_access_medical_notes()
+    {
+        Sanctum::actingAs($this->otherUser);
+
+        $this->postJson("/api/pets/{$this->pet->id}/medical-notes", [
+            'note' => 'Test',
+            'record_date' => '2024-05-01',
+        ])->assertStatus(403);
+
+        $this->getJson("/api/pets/{$this->pet->id}/medical-notes")->assertStatus(403);
+    }
+
+    public function test_unique_record_date_per_pet()
+    {
+        Sanctum::actingAs($this->owner);
+
+        $this->postJson("/api/pets/{$this->pet->id}/medical-notes", [
+            'note' => 'Visit',
+            'record_date' => '2024-01-02',
+        ])->assertCreated();
+
+        $this->postJson("/api/pets/{$this->pet->id}/medical-notes", [
+            'note' => 'Another',
+            'record_date' => '2024-01-02',
+        ])->assertStatus(422)->assertJsonValidationErrors(['record_date']);
+    }
+
+    public function test_admin_can_access_other_pets_notes()
+    {
+        $admin = User::factory()->create();
+        Role::firstOrCreate(['name' => 'admin']);
+        $admin->assignRole('admin');
+
+        Sanctum::actingAs($admin);
+        $this->postJson("/api/pets/{$this->pet->id}/medical-notes", [
+            'note' => 'Admin added note',
+            'record_date' => '2024-07-01',
+        ])->assertCreated();
+
+        $this->getJson("/api/pets/{$this->pet->id}/medical-notes")->assertOk();
+    }
+}

--- a/backend/tests/Feature/VaccinationRecordsFeatureTest.php
+++ b/backend/tests/Feature/VaccinationRecordsFeatureTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Pet;
+use App\Models\PetType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+use Spatie\Permission\Models\Role;
+
+class VaccinationRecordsFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $owner;
+    protected User $otherUser;
+    protected PetType $catType;
+    protected PetType $dogType;
+    protected Pet $cat;
+    protected Pet $dog;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->owner = User::factory()->create();
+        $this->otherUser = User::factory()->create();
+
+        $this->catType = PetType::create([
+            'id' => 1,
+            'name' => 'Cat',
+            'slug' => 'cat',
+            'is_system' => true,
+            'display_order' => 1,
+        ]);
+
+        $this->dogType = PetType::create([
+            'id' => 2,
+            'name' => 'Dog',
+            'slug' => 'dog',
+            'is_system' => true,
+            'display_order' => 2,
+        ]);
+
+        $this->cat = Pet::factory()->create([
+            'user_id' => $this->owner->id,
+            'pet_type_id' => $this->catType->id,
+        ]);
+
+        $this->dog = Pet::factory()->create([
+            'user_id' => $this->owner->id,
+            'pet_type_id' => $this->dogType->id,
+        ]);
+    }
+
+    public function test_owner_can_crud_vaccinations_for_cat()
+    {
+        Sanctum::actingAs($this->owner);
+
+        // Create
+        $create = $this->postJson("/api/pets/{$this->cat->id}/vaccinations", [
+            'vaccine_name' => 'Rabies',
+            'administered_at' => '2024-06-01',
+            'due_at' => '2025-06-01',
+            'notes' => 'Booster next year',
+        ]);
+        $create->assertStatus(201);
+        $id = $create->json('data.id');
+
+        // Index
+        $this->getJson("/api/pets/{$this->cat->id}/vaccinations")
+            ->assertOk()
+            ->assertJsonStructure(['data' => ['data', 'links', 'meta']]);
+
+        // Show
+        $this->getJson("/api/pets/{$this->cat->id}/vaccinations/{$id}")
+            ->assertOk()
+            ->assertJsonPath('data.id', $id);
+
+        // Update
+        $this->putJson("/api/pets/{$this->cat->id}/vaccinations/{$id}", [
+            'notes' => 'Updated notes',
+        ])->assertOk()->assertJsonPath('data.notes', 'Updated notes');
+
+        // Delete
+        $this->deleteJson("/api/pets/{$this->cat->id}/vaccinations/{$id}")
+            ->assertOk()->assertJson(['data' => true]);
+    }
+
+    public function test_non_owner_cannot_access_vaccinations()
+    {
+        Sanctum::actingAs($this->otherUser);
+
+        $this->postJson("/api/pets/{$this->cat->id}/vaccinations", [
+            'vaccine_name' => 'Rabies',
+            'administered_at' => '2024-06-01',
+        ])->assertStatus(403);
+
+        $this->getJson("/api/pets/{$this->cat->id}/vaccinations")->assertStatus(403);
+    }
+
+    public function test_unique_vaccination_per_date_and_name()
+    {
+        Sanctum::actingAs($this->owner);
+
+        $this->postJson("/api/pets/{$this->cat->id}/vaccinations", [
+            'vaccine_name' => 'Rabies',
+            'administered_at' => '2024-06-01',
+        ])->assertCreated();
+
+        $this->postJson("/api/pets/{$this->cat->id}/vaccinations", [
+            'vaccine_name' => 'Rabies',
+            'administered_at' => '2024-06-01',
+        ])->assertStatus(422)->assertJsonValidationErrors(['administered_at']);
+    }
+
+    public function test_admin_can_access_other_pets_vaccinations()
+    {
+        $admin = User::factory()->create();
+        Role::firstOrCreate(['name' => 'admin']);
+        $admin->assignRole('admin');
+
+        Sanctum::actingAs($admin);
+        $this->postJson("/api/pets/{$this->cat->id}/vaccinations", [
+            'vaccine_name' => 'Rabies',
+            'administered_at' => '2024-06-01',
+        ])->assertCreated();
+
+        $this->getJson("/api/pets/{$this->cat->id}/vaccinations")->assertOk();
+    }
+
+    public function test_dog_is_gated_for_vaccinations()
+    {
+        Sanctum::actingAs($this->owner);
+
+        $this->postJson("/api/pets/{$this->dog->id}/vaccinations", [
+            'vaccine_name' => 'Rabies',
+            'administered_at' => '2024-06-01',
+        ])->assertStatus(422)->assertJsonPath('error_code', 'FEATURE_NOT_AVAILABLE_FOR_PET_TYPE');
+    }
+}

--- a/backend/tests/Feature/VaccinationRemindersCommandTest.php
+++ b/backend/tests/Feature/VaccinationRemindersCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\SendVaccinationReminders;
+use App\Enums\NotificationType;
+use App\Models\Notification;
+use App\Models\NotificationPreference;
+use App\Models\Pet;
+use App\Models\PetType;
+use App\Models\User;
+use App\Models\VaccinationRecord;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class VaccinationRemindersCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Ensure pet types exist in test DB
+        PetType::factory()->create(['slug' => 'cat', 'name' => 'Cat', 'placement_requests_allowed' => true, 'weight_tracking_allowed' => true]);
+        PetType::factory()->create(['slug' => 'dog', 'name' => 'Dog', 'placement_requests_allowed' => false, 'weight_tracking_allowed' => false]);
+    }
+
+    public function test_command_sends_reminder_and_marks_record()
+    {
+        $user = User::factory()->create();
+        $petType = PetType::where('slug', 'cat')->first();
+        $pet = Pet::factory()->create(['user_id' => $user->id, 'pet_type_id' => $petType->id]);
+
+        $record = VaccinationRecord::factory()->create([
+            'pet_id' => $pet->id,
+            'vaccine_name' => 'Rabies',
+            'administered_at' => now()->subYear(),
+            'due_at' => now()->addDay(),
+            'reminder_sent_at' => null,
+        ]);
+
+        // Ensure preferences default to enabled
+        $pref = NotificationPreference::getPreference($user, NotificationType::VACCINATION_REMINDER->value);
+        $this->assertTrue($pref->email_enabled);
+        $this->assertTrue($pref->in_app_enabled);
+
+        $exitCode = Artisan::call('reminders:vaccinations', ['--days' => 3]);
+        $this->assertEquals(0, $exitCode);
+
+        $record->refresh();
+        $this->assertNotNull($record->reminder_sent_at);
+
+        $this->assertDatabaseHas('notifications', [
+            'user_id' => $user->id,
+            'type' => NotificationType::VACCINATION_REMINDER->value,
+        ]);
+    }
+
+    public function test_command_is_idempotent_per_record()
+    {
+        $user = User::factory()->create();
+        $petType = PetType::where('slug', 'cat')->first();
+        $pet = Pet::factory()->create(['user_id' => $user->id, 'pet_type_id' => $petType->id]);
+
+        $record = VaccinationRecord::factory()->create([
+            'pet_id' => $pet->id,
+            'vaccine_name' => 'Rabies',
+            'administered_at' => now()->subYear(),
+            'due_at' => now()->addDay(),
+            'reminder_sent_at' => null,
+        ]);
+
+        Artisan::call('reminders:vaccinations', ['--days' => 3]);
+        $countAfterFirst = Notification::where('user_id', $user->id)
+            ->where('type', NotificationType::VACCINATION_REMINDER->value)
+            ->count();
+
+        // Run again; should not create additional notifications for the same record
+        Artisan::call('reminders:vaccinations', ['--days' => 3]);
+        $countAfterSecond = Notification::where('user_id', $user->id)
+            ->where('type', NotificationType::VACCINATION_REMINDER->value)
+            ->count();
+
+        $this->assertGreaterThanOrEqual(1, $countAfterFirst);
+        $this->assertEquals($countAfterFirst, $countAfterSecond);
+    }
+
+    public function test_command_respects_capability_gating()
+    {
+        $user = User::factory()->create();
+        $dogType = PetType::where('slug', 'dog')->first();
+        $pet = Pet::factory()->create(['user_id' => $user->id, 'pet_type_id' => $dogType->id]);
+
+        $record = VaccinationRecord::factory()->create([
+            'pet_id' => $pet->id,
+            'vaccine_name' => 'Rabies',
+            'administered_at' => now()->subYear(),
+            'due_at' => now()->addDay(),
+            'reminder_sent_at' => null,
+        ]);
+
+        Artisan::call('reminders:vaccinations', ['--days' => 3]);
+
+        // No notifications should be created for dogs (vaccinations disabled)
+        $this->assertDatabaseMissing('notifications', [
+            'user_id' => $user->id,
+            'type' => NotificationType::VACCINATION_REMINDER->value,
+        ]);
+
+        $record->refresh();
+        $this->assertNull($record->reminder_sent_at);
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,20 +24,22 @@ Start here if you're new to the repo or want the shortest path to contributing w
 - Frontend tests: `cd frontend && npm test`
 
 3) Minimal Git flow (conflict-resistant)
-- Always branch from up-to-date main
-	- `git fetch origin && git checkout main && git pull`
+- Branches: `main` (protected), `dev` (integration), short-lived feature branches
+- Always branch from up-to-date `dev`
+	- `git fetch origin && git checkout dev && git pull`
 	- `git checkout -b feature/your-change`
 - Small, focused commits; push early, push often
 	- `git add -p && git commit -m "feat: do one thing"`
-- Sync with main regularly (weekly or before finishing)
-	- Merge (simple): `git fetch origin && git merge origin/main`
-	- Or Rebase (clean history): `git fetch origin && git rebase origin/main`
-- Open a PR from your feature branch (or merge into `dev` if that’s your team flow)
+- Sync with `dev` regularly (at least before finishing)
+	- Merge: `git fetch origin && git merge origin/dev`
+	- Or Rebase: `git fetch origin && git rebase origin/dev`
+- Open a PR: feature → `dev`. After validation, promote `dev` → `main` via PR.
 
-Pre-merge checklist
+Pre-merge checklist (feature → dev, then dev → main)
 - [ ] All tests pass: backend and frontend
 - [ ] Format/lint: `./vendor/bin/pint` (backend), `npm run typecheck && npm run lint` (frontend)
-- [ ] Rebased/merged latest `main` (or `dev`) and resolved any small conflicts
+- [ ] Rebased/merged latest `dev` (for feature PR) or latest `main` (for dev→main) and resolved any small conflicts
+- [ ] OpenAPI docs current (if backend API changed): `docker compose exec backend php artisan l5-swagger:generate`
 - [ ] Docs updated if behavior or commands changed
 
 ## Quick Paths

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,5 +42,6 @@ The core technical design, data models, and development roadmap for this project
 
 - Local setup, testing, tips: [Development Guide](./development.md)
 - Deployment steps: [Production Deployment](./deploy.md)
+- Pet Health plan & status: [Pet Health MVP](./pet-health.md)
 
 This documentation site will be expanded over time to include user guides, API references, and deployment instructions.

--- a/docs/pet-health.md
+++ b/docs/pet-health.md
@@ -1,0 +1,79 @@
+# Pet Health MVP
+
+Status updated: 2025-09-27
+
+This document consolidates the Pet Health planning (previously in `tmp/medical_md.md` and `tmp/medical_records_feature.md`) into a single source of truth.
+
+## Scope
+- [x] Weight tracking (time series)
+- [x] General medical events (notes for exams, surgeries, meds, etc.)
+- [x] Vaccinations (records)
+- [ ] Vaccination reminders (daily job)
+- [ ] Multi-chip support (Pet has many Microchips)
+
+## Data Model
+- pets (existing)
+- vaccination_records — DONE
+  - id, pet_id FK, vaccine_name string, administered_at date, due_at date nullable, notes text nullable, reminder_sent_at datetime nullable, created_at/updated_at
+- medical_notes — DONE
+  - id, pet_id FK, note text, record_date date, created_at/updated_at, unique(pet_id, record_date)
+- weight_entries — DONE (as weight_histories)
+  - id, pet_id FK, weight_g int, measured_at/record_date, created_at/updated_at
+- pet_microchips — PENDING
+  - id, pet_id FK, chip_number string unique, issuer nullable, implanted_at date nullable, created_at/updated_at
+
+Indexes
+- vaccination_records: unique (pet_id, vaccine_name, administered_at); index (pet_id, due_at)
+- medical_notes: unique (pet_id, record_date)
+- weight_histories: index (pet_id, record_date)
+
+Relationships
+- Pet hasMany WeightHistory, VaccinationRecord, MedicalNote, Microchip
+- Each record belongsTo Pet
+
+Capability gating
+- Backend via PetCapabilityService; Frontend mirrors via petSupportsCapability
+- Weight: DB-driven per PetType flag `weight_tracking_allowed` (admin toggle)
+- Medical: currently static for cats
+- Vaccinations: currently static for cats
+- Disabled types return 422 with error_code FEATURE_NOT_AVAILABLE_FOR_PET_TYPE
+
+## API Endpoints
+- Weights: /api/pets/{pet}/weights (CRUD) — implemented
+- Vaccinations: /api/pets/{pet}/vaccinations (CRUD) — implemented
+- Medical Notes: /api/pets/{pet}/medical-notes (CRUD) — implemented
+- Microchips: /api/pets/{pet}/microchips (CRUD) — planned
+
+## Authorization
+- Owner or admin; 403 for others — implemented for weights, medical notes, vaccinations
+
+## Reminders (Vaccinations)
+- Daily job scans due_at; sends notifications via existing email system
+- De-duplicate per record/day using reminder_sent_at
+- Status: Pending
+
+## Frontend
+- Health sections (owner-only)
+  - [x] Weight section with CRUD
+  - [x] Medical notes section with CRUD
+  - [x] Vaccinations section with CRUD
+- MSW handlers and client tests implemented for weights, medical notes, and vaccinations
+
+## Phases
+1) Backend weight entries — DONE
+2) Backend vaccinations — DONE
+3) Backend medical events (notes) — DONE
+4) Vaccination reminders — PENDING
+5) Backend microchips — PENDING
+6) Frontend health sections — DONE
+7) Docs + Swagger — IN PROGRESS
+
+## Acceptance Criteria
+- Proper auth and capability gating — enforced for implemented features
+- Validation rules enforced — duplicate uniqueness rules as specified
+- OpenAPI annotations present; tests green
+
+## Next Steps
+- Implement vaccination reminders job and tests
+- Extend OpenAPI where helpful and regenerate Swagger
+- Add Filament admin toggles if we later make medical/vaccinations DB-driven per type

--- a/frontend/src/api/pets.medical-notes.test.ts
+++ b/frontend/src/api/pets.medical-notes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { setupServer } from 'msw/node'
+import { handlers } from '@/mocks/handlers'
+import { createMedicalNote, deleteMedicalNote, getMedicalNotes, updateMedicalNote } from './pets'
+
+const server = setupServer(...handlers)
+
+describe('medical notes api client', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('lists medical notes with pagination envelope', async () => {
+    const res = await getMedicalNotes(1)
+    expect(res).toHaveProperty('data')
+    expect(Array.isArray(res.data)).toBe(true)
+    expect(res).toHaveProperty('links')
+    expect(res).toHaveProperty('meta')
+  })
+
+  it('creates a new medical note', async () => {
+    const note = await createMedicalNote(1, { note: 'Rabies shot', record_date: '2024-06-01' })
+    expect(note.note).toBe('Rabies shot')
+    expect(note.record_date).toBe('2024-06-01')
+  })
+
+  it('updates a medical note', async () => {
+    const note = await updateMedicalNote(1, 123, { note: 'Booster' })
+    expect(note.id).toBe(123)
+    expect(note.note).toBe('Booster')
+  })
+
+  it('deletes a medical note', async () => {
+    const ok = await deleteMedicalNote(1, 123)
+    expect(ok).toBe(true)
+  })
+})

--- a/frontend/src/api/pets.ts
+++ b/frontend/src/api/pets.ts
@@ -9,6 +9,27 @@ export interface WeightHistory {
   created_at: string
   updated_at: string
 }
+
+export interface MedicalNote {
+  id: number
+  pet_id: number
+  note: string
+  record_date: string // ISO date
+  created_at: string
+  updated_at: string
+}
+
+export interface VaccinationRecord {
+  id: number
+  pet_id: number
+  vaccine_name: string
+  administered_at: string // ISO date
+  due_at?: string | null // ISO date
+  notes?: string | null
+  reminder_sent_at?: string | null
+  created_at: string
+  updated_at: string
+}
 export const getAllPets = async (): Promise<Pet[]> => {
   const response = await api.get<{ data: Pet[] }>('/pets')
   return response.data.data
@@ -143,6 +164,87 @@ export const updateWeight = async (
 export const deleteWeight = async (petId: number, weightId: number): Promise<boolean> => {
   const response = await api.delete<{ data: boolean }>(
     `/pets/${String(petId)}/weights/${String(weightId)}`
+  )
+  return response.data.data
+}
+
+// Medical Notes API
+export const getMedicalNotes = async (
+  petId: number,
+  page = 1
+): Promise<{ data: MedicalNote[]; links: unknown; meta: unknown }> => {
+  const response = await api.get<{ data: { data: MedicalNote[]; links: unknown; meta: unknown } }>(
+    `/pets/${String(petId)}/medical-notes`,
+    { params: { page } }
+  )
+  return response.data.data
+}
+
+export const createMedicalNote = async (
+  petId: number,
+  payload: { note: string; record_date: string }
+): Promise<MedicalNote> => {
+  const response = await api.post<{ data: MedicalNote }>(`/pets/${String(petId)}/medical-notes`, payload)
+  return response.data.data
+}
+
+export const updateMedicalNote = async (
+  petId: number,
+  noteId: number,
+  payload: Partial<{ note: string; record_date: string }>
+): Promise<MedicalNote> => {
+  const response = await api.put<{ data: MedicalNote }>(
+    `/pets/${String(petId)}/medical-notes/${String(noteId)}`,
+    payload
+  )
+  return response.data.data
+}
+
+export const deleteMedicalNote = async (petId: number, noteId: number): Promise<boolean> => {
+  const response = await api.delete<{ data: boolean }>(
+    `/pets/${String(petId)}/medical-notes/${String(noteId)}`
+  )
+  return response.data.data
+}
+
+// Vaccinations API
+export const getVaccinations = async (
+  petId: number,
+  page = 1
+): Promise<{ data: VaccinationRecord[]; links: unknown; meta: unknown }> => {
+  const response = await api.get<{ data: { data: VaccinationRecord[]; links: unknown; meta: unknown } }>(
+    `/pets/${String(petId)}/vaccinations`,
+    { params: { page } }
+  )
+  return response.data.data
+}
+
+export const createVaccination = async (
+  petId: number,
+  payload: { vaccine_name: string; administered_at: string; due_at?: string | null; notes?: string | null }
+): Promise<VaccinationRecord> => {
+  const response = await api.post<{ data: VaccinationRecord }>(
+    `/pets/${String(petId)}/vaccinations`,
+    payload
+  )
+  return response.data.data
+}
+
+export const updateVaccination = async (
+  petId: number,
+  recordId: number,
+  payload: Partial<{ vaccine_name: string; administered_at: string; due_at?: string | null; notes?: string | null }>
+): Promise<VaccinationRecord> => {
+  const response = await api.put<{ data: VaccinationRecord }>(
+    `/pets/${String(petId)}/vaccinations/${String(recordId)}`,
+    payload
+  )
+  return response.data.data
+}
+
+export const deleteVaccination = async (petId: number, recordId: number): Promise<boolean> => {
+  const response = await api.delete<{ data: boolean }>(
+    `/pets/${String(petId)}/vaccinations/${String(recordId)}`
   )
   return response.data.data
 }

--- a/frontend/src/components/OwnerButtonGroup.tsx
+++ b/frontend/src/components/OwnerButtonGroup.tsx
@@ -2,22 +2,17 @@ import React from 'react'
 import { Button } from '@/components/ui/button'
 
 interface OwnerButtonGroupProps {
-  onEdit: () => void
   onPlacementRequest: () => void
   onMyCats: () => void
   showPlacementRequest?: boolean
 }
 
 export const OwnerButtonGroup: React.FC<OwnerButtonGroupProps> = ({
-  onEdit,
   onPlacementRequest,
   onMyCats,
   showPlacementRequest = true,
 }) => (
   <div className="flex gap-3 mb-4">
-    <Button onClick={onEdit} variant="outline">
-      Edit
-    </Button>
     {showPlacementRequest && (
       <Button onClick={onPlacementRequest} variant="outline">
         Placement Request

--- a/frontend/src/components/PetCard.tsx
+++ b/frontend/src/components/PetCard.tsx
@@ -59,11 +59,16 @@ export const PetCard: React.FC<PetCardProps> = ({ pet }) => {
 
   // Use unified pet route
   const petRoute = `/pets/${String(pet.id)}`
+  const isDeceased = pet.status === 'deceased'
 
   return (
     <Card className="flex flex-col overflow-hidden rounded-lg shadow-lg transition-all duration-300 hover:scale-105 hover:shadow-xl">
       <Link to={petRoute} className="block">
-        <img src={imageUrl} alt={pet.name} className="h-48 w-full object-cover" />
+        <img
+          src={imageUrl}
+          alt={pet.name}
+          className={`h-48 w-full object-cover ${isDeceased ? 'grayscale' : ''}`}
+        />
       </Link>
       <CardHeader>
         <CardTitle className="text-2xl font-bold text-primary">{pet.name}</CardTitle>

--- a/frontend/src/components/PetDetails.tsx
+++ b/frontend/src/components/PetDetails.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import type { Pet } from '@/types/pet'
 import { calculateAge, petSupportsCapability } from '@/types/pet'
 import { getStatusDisplay, getStatusClasses } from '@/utils/petStatus'
-// Using default avatar as placeholder for pets
 import placeholderImage from '@/assets/images/default-avatar.webp'
 import { Button } from '@/components/ui/button'
 import { PlacementResponseModal } from '@/components/PlacementResponseModal'
@@ -21,77 +20,232 @@ import { useAuth } from '@/hooks/use-auth'
 import { useNavigate } from 'react-router-dom'
 
 
+type PlacementRequest = NonNullable<Pet['placement_requests']>[number]
+type TransferRequest = NonNullable<PlacementRequest['transfer_requests']>[number]
+
+const deriveImageUrl = (pet: Pet): string => {
+  const photos = (pet as { photos?: { url?: string }[] }).photos
+  if (Array.isArray(photos)) {
+    const photoUrl = photos[0]?.url
+    if (photoUrl) return photoUrl
+  }
+  return pet.photo_url ?? placeholderImage
+}
+
+const isPlacementRequestActive = (request: PlacementRequest): boolean => {
+  if (typeof request.is_active === 'boolean') {
+    return request.is_active
+  }
+  return request.status === 'open' || request.status === 'pending_review'
+}
+
+const usePlacementInfo = (pet: Pet, userId?: number) => {
+  return useMemo(() => {
+    const supportsPlacement = petSupportsCapability(pet.pet_type, 'placement')
+    if (!supportsPlacement) {
+      return {
+        supportsPlacement,
+        hasActivePlacementRequest: false,
+        activePlacementRequest: undefined as PlacementRequest | undefined,
+        myPendingTransfer: undefined as TransferRequest | undefined,
+      }
+    }
+
+    const placementRequests = pet.placement_requests ?? []
+    const activePlacementRequest =
+      placementRequests.find((request) => isPlacementRequestActive(request)) ??
+      placementRequests.find((request) => request.status === 'open' || request.status === 'pending_review')
+
+    const hasActivePlacementRequest =
+      pet.placement_request_active === true ||
+      placementRequests.some((request) => isPlacementRequestActive(request))
+
+    if (!userId || !placementRequests.length) {
+      return { supportsPlacement, hasActivePlacementRequest, activePlacementRequest, myPendingTransfer: undefined }
+    }
+
+    const myPendingTransfer = placementRequests.reduce<TransferRequest | undefined>((found, request) => {
+      if (found) return found
+      return request.transfer_requests?.find((transfer) => {
+        if (transfer.status !== 'pending') return false
+        if (transfer.initiator_user_id && transfer.initiator_user_id === userId) return true
+        return transfer.helper_profile?.user?.id === userId
+      })
+    }, undefined)
+
+    return { supportsPlacement, hasActivePlacementRequest, activePlacementRequest, myPendingTransfer }
+  }, [pet, userId])
+}
+interface PlacementRequestsSectionProps {
+  placementRequests: PlacementRequest[]
+  canEdit: boolean
+  onDeletePlacementRequest: (id: number) => void | Promise<void>
+}
+
+const PlacementRequestsSection: React.FC<PlacementRequestsSectionProps> = ({
+  placementRequests,
+  canEdit,
+  onDeletePlacementRequest,
+}) => {
+  const handleDelete = useCallback(
+    async (requestId: number) => {
+      try {
+        await onDeletePlacementRequest(requestId)
+      } catch (error) {
+        console.error('Failed to delete placement request', error)
+      }
+    },
+    [onDeletePlacementRequest]
+  )
+
+  if (!placementRequests.length) {
+    return <p className="text-muted-foreground">No active placement requests</p>
+  }
+
+  return (
+    <div className="space-y-2">
+      {placementRequests.map((request) => (
+        <div key={request.id} className="flex justify-between items-center p-3 bg-background rounded border">
+          <div>
+            <span className="font-medium">{request.request_type.replace('_', ' ').toUpperCase()}</span>
+            {request.notes && <p className="text-sm text-muted-foreground">{request.notes}</p>}
+          </div>
+          {canEdit && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive" size="sm">
+                  Delete
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete Placement Request</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to delete this placement request? This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    onClick={() => void handleDelete(request.id)}
+                  >
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+interface PlacementResponseSectionProps {
+  pet: Pet
+  activePlacementRequest: PlacementRequest
+  myPendingTransfer?: TransferRequest
+  onCancelTransferRequest?: (id: number) => void | Promise<void>
+  onTransferResponseSuccess?: () => void
+}
+
+const PlacementResponseSection: React.FC<PlacementResponseSectionProps> = ({
+  pet,
+  activePlacementRequest,
+  myPendingTransfer,
+  onCancelTransferRequest,
+  onTransferResponseSuccess,
+}) => {
+  const [isRespondOpen, setIsRespondOpen] = useState(false)
+
+  const handleCancel = useCallback(async () => {
+    if (!myPendingTransfer || !onCancelTransferRequest) return
+    try {
+      await onCancelTransferRequest(myPendingTransfer.id)
+    } catch (error) {
+      console.error('Failed to cancel transfer request', error)
+    }
+  }, [myPendingTransfer, onCancelTransferRequest])
+
+  return (
+    <div className="border-t pt-4">
+      {myPendingTransfer ? (
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            You responded to this placement request. Waiting for approval...
+          </p>
+          <Button variant="outline" size="sm" onClick={() => void handleCancel()}>
+            Cancel Response
+          </Button>
+        </div>
+      ) : (
+        <Button onClick={() => setIsRespondOpen(true)} className="w-full">
+          Respond to Placement Request
+        </Button>
+      )}
+
+      <PlacementResponseModal
+        isOpen={isRespondOpen}
+        onClose={() => {
+          setIsRespondOpen(false)
+        }}
+        petName={pet.name}
+        petId={pet.id}
+        placementRequestId={activePlacementRequest.id}
+        onSuccess={onTransferResponseSuccess}
+      />
+    </div>
+  )
+}
+
 interface PetDetailsProps {
   pet: Pet
   onDeletePlacementRequest: (id: number) => void | Promise<void>
   onCancelTransferRequest?: (id: number) => void | Promise<void>
   onTransferResponseSuccess?: () => void
+  onOpenPlacementRequest?: () => void
 }
 
-export const PetDetails: React.FC<PetDetailsProps> = ({
+const PetDetails: React.FC<PetDetailsProps> = ({
   pet,
   onDeletePlacementRequest,
   onCancelTransferRequest,
   onTransferResponseSuccess,
+  onOpenPlacementRequest,
 }) => {
   const age = calculateAge(pet.birthday)
   const statusDisplay = getStatusDisplay(pet.status)
   const statusClasses = getStatusClasses(pet.status)
-  const [isRespondOpen, setIsRespondOpen] = useState(false)
   const { isAuthenticated, user } = useAuth()
   const navigate = useNavigate()
 
-  
-  // Check if this pet type supports placement requests
-  const supportsPlacement = petSupportsCapability(pet.pet_type, 'placement')
-  
-  const anyActive = Boolean(
-    pet.placement_requests?.some(
-      (r) => r.is_active ?? (r.status === 'open' || r.status === 'pending_review')
-    )
-  )
-  const hasActivePlacementRequest = pet.placement_request_active === true ? true : anyActive
-  const activePlacementRequest =
-    pet.placement_requests?.find((r) => r.is_active === true) ??
-    pet.placement_requests?.find((r) => r.status === 'open' || r.status === 'pending_review')
+  const imageUrl = useMemo(() => deriveImageUrl(pet), [pet])
 
-  // Check if current user has a pending response
-  const myPendingTransfer = React.useMemo(() => {
-    if (!user?.id || !pet.placement_requests) return undefined
-    for (const pr of pet.placement_requests) {
-      const found = pr.transfer_requests?.find((tr) => {
-        if (tr.status !== 'pending') return false
-        if (tr.initiator_user_id && tr.initiator_user_id === user.id) return true
-        return tr.helper_profile?.user?.id === user.id
-      })
-      if (found) return found
-    }
-    return undefined
-  }, [pet.placement_requests, user?.id])
+  const { supportsPlacement, hasActivePlacementRequest, activePlacementRequest, myPendingTransfer } =
+    usePlacementInfo(pet, user?.id)
 
-  // Prefer photos[0].url, then photo_url, then placeholder
-  const imageUrl =
-    (Array.isArray((pet as { photos?: { url?: string }[] }).photos)
-      ? (pet as { photos?: { url?: string }[] }).photos?.[0]?.url
-      : undefined) ??
-    pet.photo_url ??
-    placeholderImage
+  const placementRequests = pet.placement_requests ?? []
+  const showPlacementRequests = supportsPlacement && placementRequests.length > 0
+  const isDeceased = pet.status === 'deceased'
 
   const handleEditClick = () => {
-    // Use unified pet edit route
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     navigate(`/pets/${String(pet.id)}/edit`)
   }
 
   return (
     <div className="bg-card rounded-lg shadow-lg overflow-hidden">
       <div className="relative">
-        <img src={imageUrl} alt={pet.name} className="w-full h-64 object-cover" />
+        <img
+          src={imageUrl}
+          alt={pet.name}
+          className={`w-full h-64 object-cover ${isDeceased ? 'grayscale' : ''}`}
+        />
         <div className={`absolute top-4 right-4 px-3 py-1 rounded-full text-sm font-medium ${statusClasses}`}>
           {statusDisplay}
         </div>
       </div>
-      
+
       <div className="p-6">
         <div className="flex justify-between items-start mb-4">
           <div>
@@ -105,11 +259,18 @@ export const PetDetails: React.FC<PetDetailsProps> = ({
               </span>
             </div>
           </div>
-          
+
           {pet.viewer_permissions?.can_edit && (
-            <Button onClick={handleEditClick} variant="outline">
-              Edit
-            </Button>
+            <div className="flex flex-wrap justify-end gap-2">
+              {supportsPlacement && onOpenPlacementRequest && (
+                <Button onClick={onOpenPlacementRequest} variant="outline">
+                  Placement Requests
+                </Button>
+              )}
+              <Button onClick={handleEditClick} variant="outline">
+                Edit
+              </Button>
+            </div>
           )}
         </div>
 
@@ -118,120 +279,37 @@ export const PetDetails: React.FC<PetDetailsProps> = ({
             <h3 className="font-semibold text-card-foreground">Location</h3>
             <p className="text-muted-foreground">{pet.location}</p>
           </div>
-          
+
           <div>
             <h3 className="font-semibold text-card-foreground">Description</h3>
             <p className="text-muted-foreground">{pet.description}</p>
           </div>
 
-          {/* Placement Request Section - only show if pet type supports it */}
-          {supportsPlacement && (
+          {showPlacementRequests && (
             <div>
               <h3 className="font-semibold text-card-foreground">Placement Requests</h3>
-              {pet.placement_requests && pet.placement_requests.length > 0 ? (
-                <div className="space-y-2">
-                  {pet.placement_requests.map((request) => (
-                    <div key={request.id} className="flex justify-between items-center p-3 bg-background rounded border">
-                      <div>
-                        <span className="font-medium">{request.request_type.replace('_', ' ').toUpperCase()}</span>
-                        {request.notes && <p className="text-sm text-muted-foreground">{request.notes}</p>}
-                      </div>
-                      {pet.viewer_permissions?.can_edit && (
-                        <AlertDialog>
-                          <AlertDialogTrigger asChild>
-                            <Button variant="destructive" size="sm">
-                              Delete
-                            </Button>
-                          </AlertDialogTrigger>
-                          <AlertDialogContent>
-                            <AlertDialogHeader>
-                              <AlertDialogTitle>Delete Placement Request</AlertDialogTitle>
-                              <AlertDialogDescription>
-                                Are you sure you want to delete this placement request? This action cannot be undone.
-                              </AlertDialogDescription>
-                            </AlertDialogHeader>
-                            <AlertDialogFooter>
-                              <AlertDialogCancel>Cancel</AlertDialogCancel>
-                              <AlertDialogAction
-                                onClick={() => {
-                                  const run = async () => {
-                                    await onDeletePlacementRequest(request.id)
-                                  }
-                                  run().catch((error: unknown) => {
-                                    console.error('Failed to delete placement request', error)
-                                  })
-                                }}
-                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                              >
-                                Delete
-                              </AlertDialogAction>
-                            </AlertDialogFooter>
-                          </AlertDialogContent>
-                        </AlertDialog>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-muted-foreground">No active placement requests</p>
-              )}
+              <PlacementRequestsSection
+                placementRequests={placementRequests}
+                canEdit={Boolean(pet.viewer_permissions?.can_edit)}
+                onDeletePlacementRequest={onDeletePlacementRequest}
+              />
             </div>
           )}
 
-          {/* Response Section for non-owners */}
           {isAuthenticated &&
             user?.id !== pet.user_id &&
             supportsPlacement &&
             hasActivePlacementRequest &&
             activePlacementRequest && (
-              <div className="border-t pt-4">
-                {myPendingTransfer ? (
-                    <div className="space-y-2">
-                    <p className="text-sm text-muted-foreground">
-                      You responded to this placement request. Waiting for approval...
-                    </p>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          if (onCancelTransferRequest) {
-                            const run = async () => {
-                              await onCancelTransferRequest(myPendingTransfer.id)
-                            }
-                            run().catch((error: unknown) => {
-                              console.error('Failed to cancel transfer request', error)
-                            })
-                          }
-                        }}
-                      >
-                      Cancel Response
-                    </Button>
-                  </div>
-                ) : (
-                    <Button
-                      onClick={() => {
-                        setIsRespondOpen(true)
-                      }}
-                      className="w-full"
-                    >
-                    Respond to Placement Request
-                  </Button>
-                )}
-                
-                  <PlacementResponseModal
-                    isOpen={isRespondOpen}
-                    onClose={() => {
-                      setIsRespondOpen(false)
-                    }}
-                    petName={pet.name}
-                    petId={pet.id}
-                    placementRequestId={activePlacementRequest.id}
-                    onSuccess={onTransferResponseSuccess}
-                  />
-              </div>
+              <PlacementResponseSection
+                pet={pet}
+                activePlacementRequest={activePlacementRequest}
+                myPendingTransfer={myPendingTransfer}
+                onCancelTransferRequest={onCancelTransferRequest}
+                onTransferResponseSuccess={onTransferResponseSuccess}
+              />
             )}
 
-          {/* Feature availability notice for non-supporting pet types */}
           {!supportsPlacement && (
             <div className="border-t pt-4">
               <p className="text-sm text-muted-foreground text-center">
@@ -244,4 +322,6 @@ export const PetDetails: React.FC<PetDetailsProps> = ({
     </div>
   )
 }
+
+export default PetDetails
 

--- a/frontend/src/components/medical/MedicalNoteForm.tsx
+++ b/frontend/src/components/medical/MedicalNoteForm.tsx
@@ -1,52 +1,49 @@
 import React, { useState } from 'react'
 import { Button } from '@/components/ui/button'
 
-export type WeightFormValues = {
-  weight_kg: number | ''
+export type MedicalNoteFormValues = {
+  note: string
   record_date: string
 }
 
-export const WeightForm: React.FC<{
-  initial?: Partial<WeightFormValues>
-  onSubmit: (values: { weight_kg: number; record_date: string }) => Promise<void>
+export const MedicalNoteForm: React.FC<{
+  initial?: Partial<MedicalNoteFormValues>
+  onSubmit: (values: { note: string; record_date: string }) => Promise<void>
   onCancel: () => void
   submitting?: boolean
   serverError?: string | null
 }> = ({ initial, onSubmit, onCancel, submitting, serverError }) => {
-  const [weight, setWeight] = useState<number | ''>(initial?.weight_kg ?? '')
+  const [note, setNote] = useState<string>(initial?.note ?? '')
   const [date, setDate] = useState<string>(initial?.record_date ?? new Date().toISOString().split('T')[0])
-  const [errors, setErrors] = useState<{ weight_kg?: string; record_date?: string }>({})
+  const [errors, setErrors] = useState<{ note?: string; record_date?: string }>({})
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const newErrors: typeof errors = {}
-    const weightNum = typeof weight === 'string' ? Number(weight) : weight
-    if (!weightNum || Number.isNaN(weightNum) || weightNum <= 0) {
-      newErrors.weight_kg = 'Enter a valid weight (kg)'
+    if (!note || note.trim().length === 0) {
+      newErrors.note = 'Note is required'
     }
     if (!date) {
       newErrors.record_date = 'Date is required'
     }
     setErrors(newErrors)
     if (Object.keys(newErrors).length > 0) return
-    await onSubmit({ weight_kg: weightNum, record_date: date })
+    await onSubmit({ note: note.trim(), record_date: date })
   }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4" noValidate>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div>
-          <label className="block text-sm font-medium">Weight (kg)</label>
-          <input
-            type="number"
-            step="0.01"
-            min="0"
-            value={weight}
-            onChange={(e) => setWeight(e.target.value === '' ? '' : Number(e.target.value))}
+        <div className="sm:col-span-2">
+          <label className="block text-sm font-medium">Note</label>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
             className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
-            placeholder="e.g., 4.20"
+            placeholder="e.g., Vaccination: Rabies"
+            rows={3}
           />
-          {errors.weight_kg && <p className="text-xs text-red-600 mt-1">{errors.weight_kg}</p>}
+          {errors.note && <p className="text-xs text-red-600 mt-1">{errors.note}</p>}
         </div>
         <div>
           <label className="block text-sm font-medium">Date</label>
@@ -56,7 +53,9 @@ export const WeightForm: React.FC<{
             onChange={(e) => setDate(e.target.value)}
             className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
           />
-          {errors.record_date && <p className="text-xs text-red-600 mt-1">{errors.record_date}</p>}
+          {errors.record_date && (
+            <p className="text-xs text-red-600 mt-1">{errors.record_date}</p>
+          )}
         </div>
       </div>
       {serverError && <p className="text-sm text-red-600">{serverError}</p>}

--- a/frontend/src/components/vaccinations/VaccinationForm.tsx
+++ b/frontend/src/components/vaccinations/VaccinationForm.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+export type VaccinationFormValues = {
+  vaccine_name: string
+  administered_at: string
+  due_at?: string | null
+  notes?: string | null
+}
+
+export const VaccinationForm: React.FC<{
+  initial?: Partial<VaccinationFormValues>
+  onSubmit: (values: VaccinationFormValues) => Promise<void>
+  onCancel: () => void
+  submitting?: boolean
+  serverError?: string | null
+}> = ({ initial, onSubmit, onCancel, submitting, serverError }) => {
+  const [vaccineName, setVaccineName] = useState<string>(initial?.vaccine_name ?? '')
+  const [administeredAt, setAdministeredAt] = useState<string>(initial?.administered_at ?? new Date().toISOString().split('T')[0])
+  const [dueAt, setDueAt] = useState<string>(initial?.due_at ?? (() => {
+    const nextYear = new Date()
+    nextYear.setFullYear(nextYear.getFullYear() + 1)
+    return nextYear.toISOString().split('T')[0]
+  })())
+  const [notes, setNotes] = useState<string>(initial?.notes ?? '')
+  const [errors, setErrors] = useState<{ vaccine_name?: string; administered_at?: string; due_at?: string }>(
+    {}
+  )
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const newErrors: typeof errors = {}
+    if (!vaccineName || vaccineName.trim().length === 0) newErrors.vaccine_name = 'Vaccine name is required'
+    if (!administeredAt) newErrors.administered_at = 'Administered date is required'
+    if (dueAt && administeredAt && new Date(dueAt) < new Date(administeredAt)) {
+      newErrors.due_at = 'Due date must be on or after administered date'
+    }
+    setErrors(newErrors)
+    if (Object.keys(newErrors).length > 0) return
+    await onSubmit({
+      vaccine_name: vaccineName.trim(),
+      administered_at: administeredAt,
+      due_at: dueAt || null,
+      notes: notes?.trim() || null,
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label className="block text-sm font-medium">Vaccine</label>
+          <input
+            type="text"
+            value={vaccineName}
+            onChange={(e) => setVaccineName(e.target.value)}
+            className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+            placeholder="e.g., Rabies"
+          />
+          {errors.vaccine_name && <p className="text-xs text-red-600 mt-1">{errors.vaccine_name}</p>}
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Administered on</label>
+          <input
+            type="date"
+            value={administeredAt}
+            onChange={(e) => setAdministeredAt(e.target.value)}
+            className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+          />
+          {errors.administered_at && (
+            <p className="text-xs text-red-600 mt-1">{errors.administered_at}</p>
+          )}
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Due at (optional)</label>
+          <input
+            type="date"
+            value={dueAt}
+            onChange={(e) => setDueAt(e.target.value)}
+            className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+          />
+          {errors.due_at && <p className="text-xs text-red-600 mt-1">{errors.due_at}</p>}
+        </div>
+        <div className="sm:col-span-2">
+          <label className="block text-sm font-medium">Notes (optional)</label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+            rows={3}
+          />
+        </div>
+      </div>
+      {serverError && <p className="text-sm text-red-600">{serverError}</p>}
+      <div className="flex gap-2">
+        <Button type="submit" disabled={Boolean(submitting)}>
+          {submitting ? 'Saving…' : 'Save'}
+        </Button>
+        <Button type="button" variant="outline" onClick={onCancel} disabled={Boolean(submitting)}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/vaccinations/VaccinationsSection.tsx
+++ b/frontend/src/components/vaccinations/VaccinationsSection.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react'
+import { useVaccinations } from '@/hooks/useVaccinations'
+import { VaccinationForm, type VaccinationFormValues } from './VaccinationForm'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+
+export const VaccinationsSection: React.FC<{ petId: number; canEdit: boolean }> = ({ petId, canEdit }) => {
+  const { items, loading, error, create, update, remove } = useVaccinations(petId)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [adding, setAdding] = useState<boolean>(false)
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const startAdd = () => { setAdding(true); setEditingId(null); setServerError(null) }
+  const cancel = () => { setAdding(false); setEditingId(null); setServerError(null) }
+
+  const onCreate = async (values: VaccinationFormValues) => {
+    setServerError(null)
+    try {
+      await create(values)
+      setAdding(false)
+    } catch (e) {
+      setServerError('Failed to save vaccination')
+    }
+  }
+
+  const onUpdate = async (id: number, values: Partial<VaccinationFormValues>) => {
+    setServerError(null)
+    try {
+      await update(id, values)
+      setEditingId(null)
+    } catch (e) {
+      setServerError('Failed to update vaccination')
+    }
+  }
+
+  if (loading) return <div>Loading vaccinations…</div>
+  if (error) return <div className="text-red-600">{error}</div>
+
+  return (
+    <section className="mt-8">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold">Vaccinations</h2>
+        {canEdit && !adding && (
+          <Button onClick={startAdd}>Add vaccination</Button>
+        )}
+      </div>
+
+      {adding && canEdit && (
+        <div className="mt-4 rounded-md border p-4">
+          <VaccinationForm onSubmit={onCreate} onCancel={cancel} serverError={serverError} />
+        </div>
+      )}
+
+      <ul className="mt-4 space-y-3">
+        {items.length === 0 && <li className="text-sm text-muted-foreground">No vaccinations recorded yet.</li>}
+        {items.map((r) => (
+          <li key={r.id} className="rounded-md border p-4">
+            {editingId === r.id ? (
+              <VaccinationForm
+                initial={{
+                  vaccine_name: r.vaccine_name,
+                  administered_at: r.administered_at,
+                  due_at: r.due_at ?? undefined,
+                  notes: r.notes ?? undefined,
+                }}
+                onSubmit={async (v) => onUpdate(r.id, v)}
+                onCancel={() => setEditingId(null)}
+                serverError={serverError}
+              />
+            ) : (
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="font-medium">{r.vaccine_name}</div>
+                  <div className="text-sm text-muted-foreground">
+                    Administered: {new Date(r.administered_at).toLocaleDateString()}
+                  </div>
+                  {r.due_at && (
+                    <div className="text-sm text-muted-foreground">
+                      Due: {new Date(r.due_at).toLocaleDateString()}
+                    </div>
+                  )}
+                  {r.notes && <div className="text-sm">{r.notes}</div>}
+                </div>
+                {canEdit && (
+                  <div className="flex gap-2">
+                    <Button variant="outline" onClick={() => setEditingId(r.id)}>Edit</Button>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="destructive">Delete</Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Delete vaccination?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This action cannot be undone.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction onClick={() => void remove(r.id)} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                            Delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </div>
+                )}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/hooks/useCreatePetForm.ts
+++ b/frontend/src/hooks/useCreatePetForm.ts
@@ -93,10 +93,15 @@ export const useCreatePetForm = (petId?: string) => {
         try {
           setIsLoadingPet(true)
           const pet = await getPet(petId)
+          // Convert ISO date to YYYY-MM-DD format for HTML date input
+          const formatDate = (dateStr: string): string => {
+            const date = new Date(dateStr)
+            return date.toISOString().split('T')[0]
+          }
           setFormData({
             name: pet.name,
             breed: pet.breed,
-            birthday: pet.birthday,
+            birthday: formatDate(pet.birthday),
             location: pet.location,
             description: pet.description,
             pet_type_id: pet.pet_type.id,

--- a/frontend/src/hooks/useMedicalNotes.ts
+++ b/frontend/src/hooks/useMedicalNotes.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  createMedicalNote,
+  deleteMedicalNote,
+  getMedicalNotes,
+  updateMedicalNote,
+  type MedicalNote,
+} from '@/api/pets'
+
+export interface UseMedicalNotesResult {
+  items: MedicalNote[]
+  page: number
+  meta: unknown
+  links: unknown
+  loading: boolean
+  error: string | null
+  refresh: (page?: number) => Promise<void>
+  create: (payload: { note: string; record_date: string }) => Promise<MedicalNote>
+  update: (
+    id: number,
+    payload: Partial<{ note: string; record_date: string }>
+  ) => Promise<MedicalNote>
+  remove: (id: number) => Promise<boolean>
+}
+
+export const useMedicalNotes = (petId: number): UseMedicalNotesResult => {
+  const [items, setItems] = useState<MedicalNote[]>([])
+  const [page, setPage] = useState(1)
+  const [meta, setMeta] = useState<unknown>(null)
+  const [links, setLinks] = useState<unknown>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(
+    async (pg = 1) => {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await getMedicalNotes(petId, pg)
+        setItems(res.data)
+        setLinks(res.links)
+        setMeta(res.meta)
+        setPage(pg)
+      } catch (e: unknown) {
+        setError('Failed to load medical notes')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [petId]
+  )
+
+  useEffect(() => {
+    void load(1)
+  }, [load])
+
+  const refresh = useCallback(
+    async (pg?: number) => {
+      await load(pg ?? page)
+    },
+    [load, page]
+  )
+
+  const create = useCallback(
+    async (payload: { note: string; record_date: string }) => {
+      const item = await createMedicalNote(petId, payload)
+      setItems((prev) => [item, ...prev])
+      void refresh(1)
+      return item
+    },
+    [petId, refresh]
+  )
+
+  const updateOne = useCallback(
+    async (id: number, payload: Partial<{ note: string; record_date: string }>) => {
+      const item = await updateMedicalNote(petId, id, payload)
+      setItems((prev) => prev.map((n) => (n.id === id ? item : n)))
+      return item
+    },
+    [petId]
+  )
+
+  const remove = useCallback(
+    async (id: number) => {
+      const ok = await deleteMedicalNote(petId, id)
+      if (ok) setItems((prev) => prev.filter((n) => n.id !== id))
+      return ok
+    },
+    [petId]
+  )
+
+  return useMemo(
+    () => ({ items, page, meta, links, loading, error, refresh, create, update: updateOne, remove }),
+    [items, page, meta, links, loading, error, refresh, create, updateOne, remove]
+  )
+}

--- a/frontend/src/hooks/useVaccinations.ts
+++ b/frontend/src/hooks/useVaccinations.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import {
+  getVaccinations,
+  createVaccination,
+  updateVaccination,
+  deleteVaccination,
+  type VaccinationRecord,
+} from '@/api/pets'
+
+export interface UseVaccinationsResult {
+  items: VaccinationRecord[]
+  loading: boolean
+  error: string | null
+  create: (payload: { vaccine_name: string; administered_at: string; due_at?: string | null; notes?: string | null }) => Promise<void>
+  update: (id: number, payload: Partial<{ vaccine_name: string; administered_at: string; due_at?: string | null; notes?: string | null }>) => Promise<void>
+  remove: (id: number) => Promise<void>
+}
+
+export const useVaccinations = (petId: number): UseVaccinationsResult => {
+  const [items, setItems] = useState<VaccinationRecord[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const resp = await getVaccinations(petId, 1)
+      setItems(resp.data)
+    } catch (e) {
+      setError('Failed to load vaccinations')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [petId])
+
+  const create = async (payload: { vaccine_name: string; administered_at: string; due_at?: string | null; notes?: string | null }) => {
+    const created = await createVaccination(petId, payload)
+    setItems((prev) => [created, ...prev])
+  }
+
+  const update = async (
+    id: number,
+    payload: Partial<{ vaccine_name: string; administered_at: string; due_at?: string | null; notes?: string | null }>
+  ) => {
+    const updated = await updateVaccination(petId, id, payload)
+    setItems((prev) => prev.map((w) => (w.id === id ? updated : w)))
+  }
+
+  const remove = async (id: number) => {
+    await deleteVaccination(petId, id)
+    setItems((prev) => prev.filter((w) => w.id !== id))
+  }
+
+  return { items, loading, error, create, update, remove }
+}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -299,6 +299,106 @@ const weightHistoryHandlers = [
   }),
 ]
 
+const medicalNoteHandlers = [
+  http.get('http://localhost:3000/api/pets/:petId/medical-notes', () => {
+    return HttpResponse.json({
+      data: {
+        data: [],
+        links: { first: null, last: null, prev: null, next: null },
+        meta: { current_page: 1, from: null, last_page: 1, path: '/api/pets/1/medical-notes', per_page: 25, to: null, total: 0 },
+      },
+    })
+  }),
+  http.post('http://localhost:3000/api/pets/:petId/medical-notes', async ({ request, params }) => {
+    const body = (await request.json()) as { note?: string; record_date?: string }
+    if (!body.note || !body.record_date) {
+      return HttpResponse.json(
+        { message: 'Validation Error', errors: { note: ['Required'], record_date: ['Required'] } },
+        { status: 422 }
+      )
+    }
+    return HttpResponse.json({
+      data: {
+        id: Date.now(),
+        pet_id: Number(params.petId),
+        note: body.note,
+        record_date: body.record_date,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    }, { status: 201 })
+  }),
+  http.put('http://localhost:3000/api/pets/:petId/medical-notes/:noteId', async ({ request, params }) => {
+    const body = (await request.json()) as Partial<{ note: string; record_date: string }>
+    return HttpResponse.json({
+      data: {
+        id: Number(params.noteId),
+        pet_id: Number(params.petId),
+        note: body.note ?? 'Note',
+        record_date: body.record_date ?? '2024-01-01',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    })
+  }),
+  http.delete('http://localhost:3000/api/pets/:petId/medical-notes/:noteId', () => {
+    return HttpResponse.json({ data: true })
+  }),
+]
+
+const vaccinationHandlers = [
+  http.get('http://localhost:3000/api/pets/:petId/vaccinations', () => {
+    return HttpResponse.json({
+      data: {
+        data: [],
+        links: { first: null, last: null, prev: null, next: null },
+        meta: { current_page: 1, from: null, last_page: 1, path: '/api/pets/1/vaccinations', per_page: 25, to: null, total: 0 },
+      },
+    })
+  }),
+  http.post('http://localhost:3000/api/pets/:petId/vaccinations', async ({ request, params }) => {
+    const body = (await request.json()) as { vaccine_name?: string; administered_at?: string; due_at?: string | null; notes?: string | null }
+    if (!body.vaccine_name || !body.administered_at) {
+      return HttpResponse.json(
+        { message: 'Validation Error', errors: { vaccine_name: ['Required'], administered_at: ['Required'] } },
+        { status: 422 }
+      )
+    }
+    return HttpResponse.json({
+      data: {
+        id: Date.now(),
+        pet_id: Number(params.petId),
+        vaccine_name: body.vaccine_name,
+        administered_at: body.administered_at,
+        due_at: body.due_at ?? null,
+        notes: body.notes ?? null,
+        reminder_sent_at: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    }, { status: 201 })
+  }),
+  http.put('http://localhost:3000/api/pets/:petId/vaccinations/:recordId', async ({ request, params }) => {
+    const body = (await request.json()) as Partial<{ vaccine_name: string; administered_at: string; due_at?: string | null; notes?: string | null }>
+    return HttpResponse.json({
+      data: {
+        id: Number(params.recordId),
+        pet_id: Number(params.petId),
+        vaccine_name: body.vaccine_name ?? 'Rabies',
+        administered_at: body.administered_at ?? '2024-01-01',
+        due_at: body.due_at ?? null,
+        notes: body.notes ?? null,
+        reminder_sent_at: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    })
+  }),
+  http.delete('http://localhost:3000/api/pets/:petId/vaccinations/:recordId', () => {
+    return HttpResponse.json({ data: true })
+  }),
+]
+
 const placementRequestHandlers = [
   http.post('http://localhost:3000/api/placement-requests', async ({ request }) => {
     const raw = await request.json()
@@ -315,6 +415,8 @@ export const handlers = [
   ...transferRequestHandlers,
   ...versionHandlers,
   ...weightHistoryHandlers,
+  ...medicalNoteHandlers,
+  ...vaccinationHandlers,
   ...placementRequestHandlers,
   ...helperProfileHandlers,
   // notifications (simple in-memory mock)

--- a/frontend/src/pages/PetProfilePage.tsx
+++ b/frontend/src/pages/PetProfilePage.tsx
@@ -11,7 +11,7 @@ import { petSupportsCapability } from '@/types/pet'
 import { getResponderHelperProfile } from '@/api/helper-profiles'
 import { LoadingState } from '@/components/ui/LoadingState'
 import { ErrorState } from '@/components/ui/ErrorState'
-import { PetDetails } from '@/components/PetDetails'
+import PetDetails from '@/components/PetDetails'
 import { PlacementRequestModal } from '@/components/PlacementRequestModal'
 import { toast } from 'sonner'
 import { ScheduleHandoverModal } from '@/components/ScheduleHandoverModal'
@@ -25,6 +25,8 @@ import {
 import { useAuth } from '@/hooks/use-auth'
 import { Badge } from '@/components/ui/badge'
 import { WeightHistorySection } from '@/components/weights/WeightHistorySection'
+import { MedicalNotesSection } from '@/components/medical/MedicalNotesSection'
+import { VaccinationsSection } from '@/components/vaccinations/VaccinationsSection'
 
 const PetProfilePage: React.FC = () => {
   const { id } = useParams<{ id: string }>()
@@ -169,12 +171,6 @@ const PetProfilePage: React.FC = () => {
     }
   }
 
-  const handleEditClick = () => {
-    if (pet?.id) {
-      void navigate(`/pets/${String(pet.id)}/edit`)
-    }
-  }
-
   const handleMyPetsClick = () => {
     void navigate('/account/pets')
   }
@@ -220,31 +216,33 @@ const PetProfilePage: React.FC = () => {
         <div className="mb-6">
           {pet.viewer_permissions?.can_edit && (
             <OwnerButtonGroup
-              onEdit={() => {
-                handleEditClick()
-              }}
               onPlacementRequest={handleOpenModal}
               onMyCats={handleMyPetsClick}
-              showPlacementRequest={petSupportsCapability(pet.pet_type, 'placement')}
+              showPlacementRequest={false}
             />
           )}
         </div>
 
         {/* Pet Profile Content */}
-        <PetDetails
-          pet={pet}
-          onDeletePlacementRequest={(pid) => {
-            void handleDeletePlacementRequest(pid)
-          }}
-          onCancelTransferRequest={(tid) => {
-            void handleCancelMyTransferRequest(tid)
-          }}
-          onTransferResponseSuccess={refresh}
-        />
-
-        {/* Weight history (owner) */}
+          <PetDetails
+            pet={pet}
+            onDeletePlacementRequest={handleDeletePlacementRequest}
+            onCancelTransferRequest={handleCancelMyTransferRequest}
+            onTransferResponseSuccess={refresh}
+            onOpenPlacementRequest={handleOpenModal}
+          />        {/* Weight history (owner) */}
         {petSupportsCapability(pet.pet_type, 'weight') && (
           <WeightHistorySection petId={pet.id} canEdit={Boolean(pet.viewer_permissions?.can_edit)} />
+        )}
+
+        {/* Vaccinations below weight history */}
+        {petSupportsCapability(pet.pet_type, 'vaccinations') && (
+          <VaccinationsSection petId={pet.id} canEdit={Boolean(pet.viewer_permissions?.can_edit)} />
+        )}
+
+        {/* Medical notes (owner) */}
+        {petSupportsCapability(pet.pet_type, 'medical') && (
+          <MedicalNotesSection petId={pet.id} canEdit={Boolean(pet.viewer_permissions?.can_edit)} />
         )}
 
         {/* Responses Section */}

--- a/frontend/src/pages/account/CreatePetPage.edit-controls.test.tsx
+++ b/frontend/src/pages/account/CreatePetPage.edit-controls.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { MockedFunction } from 'vitest'
+import CreatePetPage from './CreatePetPage'
+import { getPet, updatePetStatus, deletePet } from '@/api/pets'
+import { AuthProvider } from '@/contexts/AuthContext'
+
+vi.mock('@/api/pets', async () => {
+  const actual = await vi.importActual<typeof import('@/api/pets')>('@/api/pets')
+  return {
+    ...actual,
+    getPet: vi.fn() as unknown as MockedFunction<(id: string) => Promise<any>>,
+    updatePetStatus: vi.fn() as unknown as MockedFunction<(id: string, status: string, password: string) => Promise<any>>,
+    deletePet: vi.fn() as unknown as MockedFunction<(id: string, password: string) => Promise<void>>,
+  }
+})
+
+// Mock sonner toast to avoid side effects
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Helper to render in edit mode with URL param
+const renderEditPage = (petId = '1', initialUser = { id: 1, name: 'User', email: 'u@e.com' }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AuthProvider initialUser={initialUser}>
+          <Routes>
+            <Route path="/pets/:id/edit" element={<CreatePetPage />} />
+          </Routes>
+        </AuthProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  , { wrapper: ({ children }) => {
+      // Navigate to edit route
+      window.history.pushState({}, 'Edit', `/pets/${petId}/edit`)
+      return <>{children}</>
+    } })
+}
+
+describe('CreatePetPage edit controls', () => {
+  const mockGetPet = getPet as unknown as MockedFunction<(id: string) => Promise<any>>
+  const mockUpdatePetStatus = updatePetStatus as unknown as MockedFunction<(id: string, status: string, password: string) => Promise<any>>
+  const mockDeletePet = deletePet as unknown as MockedFunction<(id: string, password: string) => Promise<void>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetPet.mockResolvedValue({ id: 1, status: 'active' })
+  })
+
+  it('shows current status and allows updating with password', async () => {
+    mockUpdatePetStatus.mockResolvedValue({ id: 1, status: 'lost' })
+
+    renderEditPage('1')
+
+    // Wait for current status to load
+    await waitFor(() => {
+      expect(screen.getByText(/Current status:/i)).toBeInTheDocument()
+    })
+
+    // Open select and choose Lost
+  const statusCombo = screen.getAllByRole('combobox')[1]
+  fireEvent.click(statusCombo)
+    const lost = await screen.findByText('Lost')
+    fireEvent.click(lost)
+
+    // Type password
+    const pw = screen.getAllByPlaceholderText('Confirm with your password')[0] as HTMLInputElement
+    fireEvent.change(pw, { target: { value: 'secret' } })
+
+    // Click update
+    const btn = screen.getByRole('button', { name: /Update status/i })
+    fireEvent.click(btn)
+
+    await waitFor(() => {
+      expect(mockUpdatePetStatus).toHaveBeenCalledWith('1', 'lost', 'secret')
+    })
+  })
+
+  it('requires password before updating status', async () => {
+    renderEditPage('1')
+
+    await waitFor(() => {
+      expect(screen.getByText(/Current status:/i)).toBeInTheDocument()
+    })
+
+    // Select Deceased but do not enter password
+  const statusCombo = screen.getAllByRole('combobox')[1]
+  fireEvent.click(statusCombo)
+    fireEvent.click(await screen.findByText('Deceased'))
+
+    const btn = screen.getByRole('button', { name: /Update status/i })
+    fireEvent.click(btn)
+
+    // updatePetStatus should not be called
+    await waitFor(() => {
+      expect(mockUpdatePetStatus).not.toHaveBeenCalled()
+    })
+  })
+
+  it('removes the pet when password is provided (after confirm)', async () => {
+    mockDeletePet.mockResolvedValue(undefined)
+
+    renderEditPage('1')
+
+    await waitFor(() => {
+      expect(screen.getByText(/Danger zone/i)).toBeInTheDocument()
+    })
+
+    const pwFields = screen.getAllByPlaceholderText('Confirm with your password')
+    const delPw = pwFields[pwFields.length - 1]
+    fireEvent.change(delPw, { target: { value: 'secret' } })
+
+    const removeBtn = screen.getByRole('button', { name: /Remove pet/i })
+    fireEvent.click(removeBtn)
+
+    const confirmBtn = await screen.findByRole('button', { name: /Confirm remove/i })
+    fireEvent.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(mockDeletePet).toHaveBeenCalledWith('1', 'secret')
+    })
+  })
+
+  it('does not remove the pet without password', async () => {
+    renderEditPage('1')
+
+    await waitFor(() => {
+      expect(screen.getByText(/Danger zone/i)).toBeInTheDocument()
+    })
+
+    const removeBtn = screen.getByRole('button', { name: /Remove pet/i })
+    fireEvent.click(removeBtn)
+
+    await waitFor(() => {
+      expect(mockDeletePet).not.toHaveBeenCalled()
+    })
+  })
+
+  it('asks for confirmation before removing the pet', async () => {
+    mockDeletePet.mockResolvedValue(undefined)
+
+    renderEditPage('1')
+
+    await waitFor(() => {
+      expect(screen.getByText(/Danger zone/i)).toBeInTheDocument()
+    })
+
+    // Enter password first
+    const pwFields = screen.getAllByPlaceholderText('Confirm with your password')
+    const delPw = pwFields[pwFields.length - 1]
+    fireEvent.change(delPw, { target: { value: 'secret' } })
+
+    // Click Remove pet (opens dialog)
+    const removeBtn = screen.getByRole('button', { name: /Remove pet/i })
+    fireEvent.click(removeBtn)
+
+    // Dialog appears with Confirm remove action
+    const confirmBtn = await screen.findByRole('button', { name: /Confirm remove/i })
+    expect(confirmBtn).toBeInTheDocument()
+
+    // Confirm
+    fireEvent.click(confirmBtn)
+
+    await waitFor(() => {
+      expect(mockDeletePet).toHaveBeenCalledWith('1', 'secret')
+    })
+  })
+
+  it('canceling the confirmation dialog does not remove the pet', async () => {
+    renderEditPage('1')
+
+    await waitFor(() => {
+      expect(screen.getByText(/Danger zone/i)).toBeInTheDocument()
+    })
+
+    // Provide password
+    const pwFields = screen.getAllByPlaceholderText('Confirm with your password')
+    const delPw = pwFields[pwFields.length - 1]
+    fireEvent.change(delPw, { target: { value: 'secret' } })
+
+    // Open dialog
+    fireEvent.click(screen.getByRole('button', { name: /Remove pet/i }))
+
+    // Click Cancel
+    const cancelBtn = await screen.findByRole('button', { name: /Cancel/i })
+    fireEvent.click(cancelBtn)
+
+    // Ensure API not called
+    await waitFor(() => {
+      expect(mockDeletePet).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/pages/account/CreatePetPage.tsx
+++ b/frontend/src/pages/account/CreatePetPage.tsx
@@ -1,14 +1,34 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { FormField } from '@/components/ui/FormField'
 import { FileInput } from '@/components/ui/FileInput'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { useCreatePetForm } from '@/hooks/useCreatePetForm'
+import { Input } from '@/components/ui/input'
+import { deletePet, updatePetStatus, getPet } from '@/api/pets'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
 
 const CreatePetPage: React.FC = () => {
   const { id: petId } = useParams<{ id: string }>()
   const isEditMode = Boolean(petId)
+  const [currentStatus, setCurrentStatus] = useState<'active' | 'lost' | 'deceased' | 'deleted' | ''>('')
+  const [newStatus, setNewStatus] = useState<'active' | 'lost' | 'deceased' | ''>('')
+  const [statusPassword, setStatusPassword] = useState('')
+  const [deletePassword, setDeletePassword] = useState('')
+  const [isUpdatingStatus, setIsUpdatingStatus] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   
   const { 
     formData, 
@@ -22,6 +42,68 @@ const CreatePetPage: React.FC = () => {
     handleSubmit, 
     handleCancel 
   } = useCreatePetForm(petId)
+
+  // Load current status in edit mode
+  useEffect(() => {
+    if (!isEditMode || !petId) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const pet = await getPet(petId)
+        if (!cancelled) {
+          const st = (pet.status ?? 'active') as 'active' | 'lost' | 'deceased' | 'deleted'
+          setCurrentStatus(st)
+          setNewStatus(st === 'deleted' ? 'active' : (st as 'active' | 'lost' | 'deceased'))
+        }
+      } catch {
+        /* ignore */
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isEditMode, petId])
+
+  const handleUpdateStatusClick = async () => {
+    if (!petId) return
+    if (!newStatus) {
+      toast.error('Please select a status')
+      return
+    }
+    if (!statusPassword.trim()) {
+      toast.error('Please enter your password to confirm')
+      return
+    }
+    try {
+      setIsUpdatingStatus(true)
+      const updated = await updatePetStatus(petId, newStatus, statusPassword)
+      setCurrentStatus(updated.status as 'active' | 'lost' | 'deceased' | 'deleted')
+      toast.success('Status updated')
+    } catch (e) {
+      toast.error('Failed to update status')
+    } finally {
+      setIsUpdatingStatus(false)
+    }
+  }
+
+  const handleDeletePetClick = async () => {
+    if (!petId) return
+    if (!deletePassword.trim()) {
+      toast.error('Please enter your password to confirm')
+      return
+    }
+    try {
+      setIsDeleting(true)
+      await deletePet(petId, deletePassword)
+      toast.success('Pet removed')
+      // Reuse cancel navigation to go back to My Pets
+      handleCancel()
+    } catch (e) {
+      toast.error('Failed to remove pet')
+    } finally {
+      setIsDeleting(false)
+    }
+  }
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background">
@@ -139,6 +221,91 @@ const CreatePetPage: React.FC = () => {
             </Button>
           </div>
         </form>
+        )}
+
+        {isEditMode && (
+          <div className="mt-10 space-y-6">
+            <div className="border-t pt-6">
+              <h2 className="text-xl font-semibold text-card-foreground">Status</h2>
+              <p className="text-sm text-muted-foreground mb-4">
+                Current status: <span className="font-medium">{currentStatus || '...'}</span>
+              </p>
+              <div className="grid gap-3 sm:grid-cols-[200px_1fr] items-center">
+                <div className="text-sm font-medium">New status</div>
+                <div>
+                  <Select value={newStatus} onValueChange={(v) => setNewStatus(v as 'active' | 'lost' | 'deceased')}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select status" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="active">Active</SelectItem>
+                      <SelectItem value="lost">Lost</SelectItem>
+                      <SelectItem value="deceased">Deceased</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="text-sm font-medium">Password</div>
+                <div>
+                  <Input
+                    type="password"
+                    placeholder="Confirm with your password"
+                    value={statusPassword}
+                    onChange={(e) => setStatusPassword(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="mt-4">
+                <Button onClick={() => { void handleUpdateStatusClick() }} disabled={isUpdatingStatus}>
+                  {isUpdatingStatus ? 'Updating...' : 'Update status'}
+                </Button>
+              </div>
+            </div>
+
+            <div className="border-t pt-6">
+              <h2 className="text-xl font-semibold text-destructive">Danger zone</h2>
+              <p className="text-sm text-muted-foreground mb-4">
+                Removing this pet is irreversible. All associated data will be deleted.
+              </p>
+              <div className="grid gap-3 sm:grid-cols-[200px_1fr] items-center">
+                <div className="text-sm font-medium">Password</div>
+                <div>
+                  <Input
+                    type="password"
+                    placeholder="Confirm with your password"
+                    value={deletePassword}
+                    onChange={(e) => setDeletePassword(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="mt-4">
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="destructive" disabled={isDeleting}>
+                      {isDeleting ? 'Removing...' : 'Remove pet'}
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Remove pet?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This action is irreversible. Type your password and click confirm to proceed.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        onClick={() => { void handleDeletePetClick() }}
+                      >
+                        Confirm remove
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/types/pet.ts
+++ b/frontend/src/types/pet.ts
@@ -133,7 +133,14 @@ export const petSupportsCapability = (petType: PetType, capability: string): boo
   if (capability === 'weight') {
     return Boolean(petType.weight_tracking_allowed)
   }
-  // All other capabilities (medical, ownership, weight, comments, status_update, photos) 
-  // are allowed for all pet types
+  // Medical capability: static for now (cats supported). Backend enforces this too.
+  if (capability === 'medical') {
+    return petType.slug?.toLowerCase() === 'cat'
+  }
+  // Vaccinations capability: static for now (cats supported). Backend enforces this too.
+  if (capability === 'vaccinations') {
+    return petType.slug?.toLowerCase() === 'cat'
+  }
+  // All other capabilities (ownership, comments, status_update, photos) are allowed for all pet types
   return true
 }


### PR DESCRIPTION
This PR completes the Pet Health MVP on the frontend and wires up supporting backend pieces.

Highlights
- Vaccinations section (owner-only) with full CRUD and capability gating
- Default dates in forms: today for weights/medical notes; vaccinations administered_at=today, due_at=+1 year
- Human-readable date rendering across health UIs (no raw ISO strings)
- Restored Remove/status change dialog in PetDetails (lost/deceased) with password confirmation and toasts
- Fixed 403 on pet profile update by normalizing date inputs (ISO -> YYYY-MM-DD)
- Removed duplicate Edit button in owner actions
- Docs + CHANGELOG updated

Quality
- Frontend: all tests passing (224)
- Backend Feature: all tests passing; targeted weight/medical/vaccination suites green

How to validate
- Open a pet profile (cat), verify Weight, Medical Notes, and Vaccinations sections
- Add/edit/delete items; verify defaults and readable dates
- Change pet status to lost/deceased via Remove button

Follow-ups
- Vaccination reminders job (daily scan + notifications)
- Optional: expand Swagger docs further and admin toggles for DB-driven capabilities.