### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project are documented here, following the [Keep a C
 - PgAdmin interface for local database management
 - Enhanced documentation for PostgreSQL-only development workflow
 
+### Fixed
+- Resolved test failures after SQLite removal by installing `postgresql-client` and fixing test setup to use seeders.
+
 ### Removed
 - SQLite database connection configuration and references
 - `sqlite3` package from Docker image (no longer needed)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,7 +18,7 @@ This is the AI-agent-oriented guide: architecture, conventions, workf- Backend t
 
 -   **Backend:** Laravel (PHP) REST API with a Filament Admin Panel.
 -   **Frontend:** React (TypeScript) SPA with Vite, Tailwind CSS, and shadcn/ui.
--   **Database:** PostgreSQL (all environments).
+-   **Database:** PostgreSQL (all environments). SQLite is no longer supported.
 -   **Deployment:** Docker Compose with an optimized multi-stage build.
 
 ### Core Architectural Principles
@@ -116,8 +116,8 @@ When debugging:
 ### Common Debugging Scenarios & Solutions
 
 - Backend tests: schema mismatches
-  - Symptom: “no such column” in tests using `RefreshDatabase`.
-  - Fix: remove conflicting migrations; add new columns to initial creates; ensure `DB_CONNECTION=sqlite`, `DB_DATABASE=:memory:` in test env; `php artisan optimize:clear`.
+  - Symptom: "no such column" or "foreign key constraint" errors in tests using `RefreshDatabase`.
+  - Fix: Ensure tests that create data also seed necessary dependencies (e.g., `PetTypeSeeder`). If `psql` is not found, install `postgresql-client` locally. Clear config/cache with `php artisan optimize:clear`.
 
 - Local DB driver issues
   - Symptom: `could not find driver` for PostgreSQL.

--- a/backend/tests/Unit/PetCapabilityServiceTest.php
+++ b/backend/tests/Unit/PetCapabilityServiceTest.php
@@ -18,9 +18,9 @@ class PetCapabilityServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        // Ensure pet types exist (with fixed ids for deterministic tests)
-        PetType::create(['id' => 1, 'name' => 'Cat', 'slug' => 'cat', 'is_system' => true, 'is_active' => true, 'display_order' => 0, 'placement_requests_allowed' => true]);
-        PetType::create(['id' => 2, 'name' => 'Dog', 'slug' => 'dog', 'is_system' => true, 'is_active' => true, 'display_order' => 1]);
+        
+        // Run the PetTypeSeeder to ensure pet types exist with correct capabilities
+        $this->seed(\Database\Seeders\PetTypeSeeder::class);
     }
 
     #[Test]

--- a/docs/development.md
+++ b/docs/development.md
@@ -168,7 +168,8 @@ Requirements
 - PHP 8.4+
 - Composer
 - Node.js 18+
- - Database: Prefer Postgres. SQLite is no longer recommended after schema squashing.
+- PostgreSQL Client Tools (`psql` command)
+- Database: Prefer Postgres. SQLite is no longer recommended after schema squashing.
 
 1) Backend
 ```bash

--- a/utils/dev-pgsql-docker/README.md
+++ b/utils/dev-pgsql-docker/README.md
@@ -4,6 +4,16 @@ This directory contains a Docker Compose setup for running PostgreSQL locally fo
 
 ## Quick Start
 
+### Option A: Automated Setup (Recommended)
+```bash
+cd utils/dev-pgsql-docker
+./fresh-db.sh
+cd ../../backend
+php artisan db:seed
+php artisan serve
+```
+
+### Option B: Manual Setup
 1. **Start the database**:
    ```bash
    cd utils/dev-pgsql-docker
@@ -46,16 +56,22 @@ These settings are already configured in `backend/.env`.
 
 ## PgAdmin Setup
 
-After accessing PgAdmin at http://localhost:8888:
+After accessing PgAdmin at http://localhost:8888 (admin@example.com / admin123):
 
-1. Click "Add New Server"
-2. General tab: Name = "Local Dev"
-3. Connection tab:
-   - Host: `postgres` (Docker Compose service name for internal container communication)
-   - Port: 5432
-   - Database: meo_mai_moi
-   - Username: user
-   - Password: password
+1. **First Login**: Use email `admin@example.com` and password `admin123`
+2. **Add Server Connection**:
+   - Click "Add New Server" or go to Object Explorer → Create → Server
+3. **General Tab**: 
+   - Name: `Local Dev` (or any name you prefer)
+4. **Connection Tab**:
+   - Host name/address: `postgres` (Docker Compose service name for internal container communication)
+   - Port: `5432`
+   - Database: `meo_mai_moi`
+   - Username: `user`
+   - Password: `password`
+5. **Save**: Click "Save" to create the connection
+
+**Important**: Use `postgres` as the host name, not `localhost` or `127.0.0.1`. This is because PgAdmin runs inside a Docker container and needs to connect to the PostgreSQL container using the internal Docker network.
 
 ## Troubleshooting
 

--- a/utils/dev-pgsql-docker/fresh-db.sh
+++ b/utils/dev-pgsql-docker/fresh-db.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Fresh Database Setup Script
+# This script recreates the database and loads the schema for native development
+
+set -e  # Exit on any error
+
+echo "🔄 Setting up fresh database for native development..."
+
+# Check if we're in the right directory
+if [ ! -f "docker-compose.yml" ]; then
+    echo "❌ Error: Run this script from utils/dev-pgsql-docker directory"
+    exit 1
+fi
+
+# Check if containers are running
+if ! docker compose ps | grep -q "Up"; then
+    echo "🚀 Starting PostgreSQL containers..."
+    docker compose up -d
+    echo "⏳ Waiting for database to be ready..."
+    sleep 5
+fi
+
+# Copy schema file into container
+echo "📄 Copying schema file..."
+docker cp ../../backend/database/schema/pgsql-schema.sql postgres_dev:/tmp/schema.sql
+
+# Drop and recreate database
+echo "🗑️  Dropping existing database..."
+docker compose exec postgres dropdb -U user meo_mai_moi 2>/dev/null || echo "Database didn't exist, continuing..."
+
+echo "🆕 Creating fresh database..."
+docker compose exec postgres createdb -U user meo_mai_moi
+
+# Load schema
+echo "📋 Loading schema..."
+docker compose exec postgres psql -U user -d meo_mai_moi -f /tmp/schema.sql > /dev/null
+
+echo "✅ Database setup complete!"
+echo ""
+echo "Next steps:"
+echo "  cd ../../backend"
+echo "  php artisan db:seed"
+echo "  php artisan serve"
+echo ""
+echo "Access points:"
+echo "  • Laravel: http://localhost:8000 (or 8001 if 8000 is busy)"
+echo "  • PgAdmin: http://localhost:8888 (admin@example.com / admin123)"

--- a/utils/dev-pgsql-docker/fresh-db.sh
+++ b/utils/dev-pgsql-docker/fresh-db.sh
@@ -17,7 +17,19 @@ if ! docker compose ps | grep -q "Up"; then
     echo "🚀 Starting PostgreSQL containers..."
     docker compose up -d
     echo "⏳ Waiting for database to be ready..."
-    sleep 5
+    # Wait for PostgreSQL to be ready using pg_isready
+    for i in {1..30}; do
+        if docker compose exec -T postgres pg_isready -U user > /dev/null 2>&1; then
+            echo "✅ Database is ready!"
+            break
+        else
+            sleep 1
+        fi
+        if [ "$i" -eq 30 ]; then
+            echo "❌ Database did not become ready in time."
+            exit 1
+        fi
+    done
 fi
 
 # Copy schema file into container

--- a/utils/dev-pgsql-docker/fresh-db.sh
+++ b/utils/dev-pgsql-docker/fresh-db.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Fresh Database Setup Script
 # This script recreates the database and loads the schema for native development
+#
+# Before running, make sure this script is executable:
+#   chmod +x fresh-db.sh
 
 set -e  # Exit on any error
 

--- a/utils/dev-pgsql-docker/fresh-db.sh
+++ b/utils/dev-pgsql-docker/fresh-db.sh
@@ -48,7 +48,11 @@ docker compose exec postgres createdb -U user meo_mai_moi
 
 # Load schema
 echo "📋 Loading schema..."
-docker compose exec postgres psql -U user -d meo_mai_moi -f /tmp/schema.sql > /dev/null
+if ! OUTPUT=$(docker compose exec postgres psql -U user -d meo_mai_moi -f /tmp/schema.sql 2>&1 > /dev/null); then
+    echo "❌ Error loading schema:"
+    echo "$OUTPUT"
+    exit 1
+fi
 
 echo "✅ Database setup complete!"
 echo ""


### PR DESCRIPTION
This pull request focuses on improving developer experience and reliability by standardizing on PostgreSQL, removing SQLite support, and making local setup and testing more robust. Documentation has been updated to reflect these changes, and a new script is introduced to automate fresh database setup for local development.

**Database Standardization & Setup Improvements:**

* Added a new `fresh-db.sh` script in `utils/dev-pgsql-docker` to automate dropping, recreating, and loading the PostgreSQL schema for local development. This simplifies onboarding and ensures a consistent environment.
* Updated `utils/dev-pgsql-docker/README.md` with a recommended quick-start guide using the new script, clarified PgAdmin setup steps (including default credentials and host guidance), and emphasized using PostgreSQL exclusively. [[1]](diffhunk://#diff-24d56443f848e4e88a7cd63a85d4999ebb83767b481d90364f00f94116509f61R7-R16) [[2]](diffhunk://#diff-24d56443f848e4e88a7cd63a85d4999ebb83767b481d90364f00f94116509f61L49-R74)

**Testing Reliability Fixes:**

* Fixed test failures after SQLite removal by ensuring tests seed necessary data using `PetTypeSeeder` and documenting the need for `postgresql-client` in test environments. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18-R20) [[2]](diffhunk://#diff-955be4956dd1b9438d9c4fb84d3de055169ac2193a5175eacc4b5ecd5dba3612L21-R23)
* Updated debugging documentation in `GEMINI.md` to address common PostgreSQL test issues and solutions, removing SQLite-specific instructions.

**Documentation Consistency:**

* Updated all documentation (`GEMINI.md`, `docs/development.md`) to clearly state that only PostgreSQL is supported and SQLite is no longer recommended or supported. [[1]](diffhunk://#diff-399080f41ccf73c6004e0f85c0a58fc1767080a0ef19bb3f3a90caa14f94bd79L21-R21) [[2]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeR171)

These changes collectively streamline the development workflow, reduce confusion around database support, and make local setup and testing more reliable.