### PR TITLE
docs: refactor GEMINI.md (align with development.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project are documented here, following the [Keep a C
 - PgAdmin interface for local database management
 - Enhanced documentation for PostgreSQL-only development workflow
 
+### Fixed
+- Resolved test failures after SQLite removal by installing `postgresql-client` and fixing test setup to use seeders.
+
 ### Removed
 - SQLite database connection configuration and references
 - `sqlite3` package from Docker image (no longer needed)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,7 +18,7 @@ This is the AI-agent-oriented guide: architecture, conventions, workf- Backend t
 
 -   **Backend:** Laravel (PHP) REST API with a Filament Admin Panel.
 -   **Frontend:** React (TypeScript) SPA with Vite, Tailwind CSS, and shadcn/ui.
--   **Database:** PostgreSQL (all environments).
+-   **Database:** PostgreSQL (all environments). SQLite is no longer supported.
 -   **Deployment:** Docker Compose with an optimized multi-stage build.
 
 ### Core Architectural Principles
@@ -116,8 +116,8 @@ When debugging:
 ### Common Debugging Scenarios & Solutions
 
 - Backend tests: schema mismatches
-  - Symptom: “no such column” in tests using `RefreshDatabase`.
-  - Fix: remove conflicting migrations; add new columns to initial creates; ensure `DB_CONNECTION=sqlite`, `DB_DATABASE=:memory:` in test env; `php artisan optimize:clear`.
+  - Symptom: "no such column" or "foreign key constraint" errors in tests using `RefreshDatabase`.
+  - Fix: Ensure tests that create data also seed necessary dependencies (e.g., `PetTypeSeeder`). If `psql` is not found, install `postgresql-client` locally. Clear config/cache with `php artisan optimize:clear`.
 
 - Local DB driver issues
   - Symptom: `could not find driver` for PostgreSQL.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,278 +1,90 @@
-# GEMINI.md — AI Agent Guide for Meo Mai Moi
+# GEMINI.md — AI Agent Guide
 
-This is the AI-agent-oriented guide: architecture, conventions, workf- Backend tests: schema mismatches
-  - Symptom: "no such column" in tests using `RefreshDatabase`.
-  - Fix: remove conflicting migrations; add new columns to initial creates; ensure proper DB config in test env; `php artisan optimize:clear`.
+Concise, AI-facing guide for architecture, workflows, testing, and troubleshooting. For full developer instructions, see `docs/development.md`. For native Postgres setup, see `utils/dev-pgsql-docker/README.md`.
 
-## 1. Project Summary
+## 1) What this app is
 
-**Meo Mai Moi** is an open-source web application designed to help communities build pet rehoming networks. It connects pet owners with fosters and adopters, supporting a community-driven approach to pet welfare with support for multiple pet types (cats, dogs, and more).
+Meo Mai Moi helps communities rehome pets. Users can list pets, manage helper profiles, and coordinate placements. Admins moderate and manage the system.
 
-## 2. Application Structure (User POV)
+## 2) Tech and architecture
 
--   **Public Area:** Homepage, Available Pets, Pet Profiles, Available Helpers, Helper Profiles, Login/Registration.
--   **User Dashboard:** Account management, manage personal pet listings, manage helper profile, notifications.
--   **Admin Dashboard:** Manage all pets, pet types, users, applications, and transfers.
+- Backend: Laravel (PHP) + Filament admin
+- Frontend: React + TypeScript + Vite + Tailwind + shadcn/ui
+- Database: PostgreSQL only (all envs). SQLite is not supported.
+- Build/Run: Docker Compose; frontend assets copied into backend image in multi-stage builds
+- API First: OpenAPI annotations; contract tests enforce parity
 
-## 3. Tech Stack & Core Architecture
+Key models and auth
+- RBAC via Spatie Permission (single source of truth). The legacy `users.role` column is removed.
+- Policies prefer `$user->can(...)`; permissions like `view_pet`, `create_pet`, etc.
+- Pet status enum: `active`, `lost`, `deceased`, `deleted`.
+- Pet types (Cat, Dog, …) with capability gating via `PetCapabilityService`.
+- React `AuthProvider` manages session auth; Axios interceptor handles cookies.
+- File uploads live under `storage/app/public` (exposed via `public/storage`).
 
--   **Backend:** Laravel (PHP) REST API with a Filament Admin Panel.
--   **Frontend:** React (TypeScript) SPA with Vite, Tailwind CSS, and shadcn/ui.
--   **Database:** PostgreSQL (all environments). SQLite is no longer supported.
--   **Deployment:** Docker Compose with an optimized multi-stage build.
+## 3) Development basics (quick)
 
-### Core Architectural Principles
+Preferred: Docker
+- Start: `docker compose up -d --build`
+- First-time init: `docker compose exec backend php artisan migrate:fresh --seed && docker compose exec backend php artisan shield:generate --all && docker compose exec backend php artisan storage:link`
+- App: http://localhost:8000, Admin: http://localhost:8000/admin, Vite (optional): http://localhost:5173
 
-- **API First:** OpenAPI annotations + contract testing keep docs and code in sync.
-- **Self-Service & Moderation:** Users manage their content; admins handle exceptions.
-- **Mobile First:** Responsive UI and performance-friendly patterns.
+Native (fast loop) with Dockerized Postgres
+- Requirements: PHP 8.4+, Composer, Node 18+, PostgreSQL client tools (`psql`).
+- Start DB: `cd utils/dev-pgsql-docker && docker compose up -d`
+- Backend: `cd backend && php artisan migrate:fresh --seed && php artisan shield:generate --all && php artisan storage:link && php artisan serve`
+- Note: `php artisan serve` requires the dev Postgres container running.
 
-### Core Data Models
+## 4) Testing
 
--   **User Roles (RBAC):** Spatie Laravel Permission is the single source of truth. Roles are assigned via Spatie (e.g., `admin`, `super_admin`, `owner`, `helper`, `viewer`). The legacy `users.role` column has been removed via migration and should not be used.
--   **Permissions:** A granular system (`view_pet`, `create_pet`, etc.) is managed by Spatie + Filament Shield. Policies prefer ownership checks and `$user->can(...)`.
--   **Pet Status:** The `Pet` model uses a status enum: `active`, `lost`, `deceased`, `deleted`.
--   **Pet Types:** The `PetType` model defines available pet types (Cat, Dog, etc.) with capability enforcement through `PetCapabilityService`.
+Backend (Pest/PHPUnit)
+- Run: `docker compose exec backend php artisan test` (or `cd backend && php artisan test` natively)
+- With schema dumps: tests call `psql` for `RefreshDatabase`; install `postgresql-client` locally if missing.
+- Seed dependencies in tests (e.g., `PetTypeSeeder`) to avoid FK and enum gaps.
 
-### Pet Capability Matrix
+Frontend (Vitest + RTL)
+- Run: `cd frontend && npm test`
+- MSW for API mocking: global server in `frontend/src/setupTests.ts`; handlers per resource under `frontend/src/mocks` using absolute URLs; mirror `{ data: ... }` API shape.
+- `sonner` toasts are mocked in `frontend/src/setupTests.ts`.
 
-The system enforces different feature availability based on pet type:
+## 5) Non-obvious workflows
 
-| Capability      | Cat | Dog | Notes |
-|-----------------|-----|-----|-------|
-| placement       | ✅  | ❌  | Placement requests (fostering/adoption) |
-| fostering       | ✅  | ❌  | Foster assignment workflows |
-| medical         | ✅  | ❌  | Medical records and tracking |
-| ownership       | ✅  | ❌  | Transfer and adoption workflows |
-| weight          | ✅  | ❌  | Weight tracking and history |
-| comments        | ✅  | ❌  | Comments and notes system |
-| status_update   | ✅  | ❌  | Status changes (lost, deceased, etc.) |
-| photos          | ✅  | ✅  | Photo uploads and management |
+- Frontend build feeds backend views (see `welcome.blade.php`). Docker build compiles frontend first, then copies assets into the backend image.
+- Runtime setup happens in `backend/docker-entrypoint.sh` (e.g., `storage:link`). Check here for upload issues.
+- Email settings are database-driven via Filament at `/admin/email-configurations`. An active DB config overrides `.env` `MAIL_*`.
 
-**Error Handling:** When a capability is not available for a pet type, the API returns a 422 error with `error_code: "FEATURE_NOT_AVAILABLE_FOR_PET_TYPE"`.
+## 6) Debugging playbook
 
-Note: Actual capability availability is controlled via `PetType` configuration in the database and enforced by `PetCapabilityService`. The matrix above shows defaults rather than hard-coded behavior.
+General loop
+1) Observe the exact error/behavior
+2) Isolate (backend logs, browser devtools)
+3) Fix one hypothesis
+4) Verify: rebuild/restart, `php artisan optimize:clear`, retest
 
-### Authentication
-
-React Context (`AuthProvider`) manages session auth; Axios interceptor handles cookies.
-
-### File Uploads
-
-Files live in `storage/app/public`, exposed via `public/storage` symlink (`php artisan storage:link`). `FileUploadService` handles ops + image optimization.
-
-## 4. Atypical Project Aspects & Key Workflows
-
-This project has several specific, non-standard workflows that are critical to understand.
-
--   **Tightly Coupled Frontend/Backend Build:**
-  - `frontend` build also updates backend view assets (see `welcome.blade.php`).
-  - Docker multi-stage builds frontend first, then copies assets into backend image.
-
--   **Strict API Contract Testing:**
-  - CI enforces parity with OpenAPI. When changing endpoints: update `@OA` annotations, run `php artisan l5-swagger:generate`, commit updated docs.
-
--   **Runtime Container Setup:**
-  - `backend/docker-entrypoint.sh` runs setup on start (notably `storage:link` as `www-data`). Check here first for upload issues.
-
--   **Database-Driven Email Configuration:**
-    -   Email provider settings can be managed via the **Email Configuration** section in the Filament admin panel (`/admin/email-configurations`).
-    -   These settings are stored in the database. An **active** configuration in the admin panel will **always override** the `MAIL_*` settings in the `.env` file.
-    -   For local development, using the `.env` file is fine, but ensure no configuration is marked as "active" in the admin panel if you want to use the `.env` settings.
-
-## 5. Development Practices
-
-### Versioning & Changelog
-
-Semantic Versioning (e.g., `0.4.0`). Track changes in `CHANGELOG.md` under `[Unreleased]` → `Added/Changed/Fixed` with short user-facing lines. Older entries are archived in `HISTORY.md`.
-
-### Testing Strategy
-
-- Backend (Pest): unit + feature tests; prefer realistic request/response cycles.
-- Frontend (Vitest + RTL): shared `renderWithRouter`, centralized mock data.
-
-#### Frontend API Mocking (MSW)
-
-For API mocking, we use **Mock Service Worker (MSW)**. It intercepts network requests and returns mocked data.
-
-**Key Principles:**
-1. Global server in `frontend/src/setupTests.ts`.
-2. Centralized handlers per resource (e.g., `frontend/src/mocks/data/pets.ts`).
-3. Absolute URLs in handlers (e.g., `http://localhost:3000/api/pets`).
-4. Mirror real API shape, including `{ "data": ... }` wrapper.
-
-#### Mocking UI Libraries (`sonner`)
-
-`sonner` (toasts) needs a mock in `frontend/src/setupTests.ts` to prevent failures (mock `Toaster` and `toast.*`). See file for the current stub.
-
-### Debugging Strategy
-
-When debugging:
-1) Understand the symptom (message/status/behavior)
-2) Isolate (backend logs, nginx/php.ini, browser devtools)
-3) Hypothesize → targeted fix
-4) Verify (rebuild/restart, `optimize:clear`, re-test)
-
-### Common Debugging Scenarios & Solutions
-
-- Backend tests: schema mismatches
-  - Symptom: "no such column" or "foreign key constraint" errors in tests using `RefreshDatabase`.
-  - Fix: Ensure tests that create data also seed necessary dependencies (e.g., `PetTypeSeeder`). If `psql` is not found, install `postgresql-client` locally. Clear config/cache with `php artisan optimize:clear`.
-
-- Local DB driver issues
-  - Symptom: `could not find driver` for PostgreSQL.
-  - Fix: install `pdo_pgsql`; `php artisan config:clear`; verify via tinker.
-
+Common issues
+- Backend tests: schema or FK errors with `RefreshDatabase`
+  - Ensure dependent seeders run (e.g., `PetTypeSeeder`). Install `postgresql-client` if `psql` missing. Clear caches with `php artisan optimize:clear`.
+- DB driver missing
+  - Error: `could not find driver` → install `pdo_pgsql`, then `php artisan config:clear`.
 - 403 in backend tests (policies)
-  - Causes: wrong role/auth, missing policy, bad data state, missing relationships, mass assignment.
-  - Fix: inspect `response->json()`, verify factories/roles/states, eager-load needed relations, check `$fillable`, clear caches.
+  - Check roles/auth, factories/states, policies, mass assignment; inspect `response->json()`.
+- OpenAPI generation errors
+  - Fix minor `@OA` syntax (brackets/commas). Re-run `php artisan l5-swagger:generate`.
+- Frontend test environment gaps (Radix/shadcn)
+  - Polyfills and DOM stubs live in `frontend/src/setupTests.ts` (PointerEvent, `scrollIntoView`, etc.).
 
-- OpenAPI generation fails
-  - Fix: follow error path/line; fix subtle `@OA` syntax (commas/brackets/parentheses).
+## 7) Linting & formatting
 
-- Frontend tests: missing browser APIs (Radix/shadcn)
-  - Symptom: `hasPointerCapture` / `scrollIntoView` errors; flaky dropdown interactions.
-  - Fix: polyfills live in `frontend/src/setupTests.ts` (PointerEvent + methods, scrollIntoView). Keep them enabled.
+- Backend: Laravel Pint (`./vendor/bin/pint`).
+- Frontend: ESLint + Prettier + TypeScript (`npm run lint`, `npm run typecheck`).
 
-### Coding Style
+## 8) Quick commands
 
-- PHP/Laravel: PSR-12 via PHP-CS-Fixer; TypeScript/React: Airbnb via Prettier/ESLint.
+- Start (Docker): `docker compose up -d --build`
+- Backend tests: `docker compose exec backend php artisan test`
+- Frontend tests: `cd frontend && npm test`
+- Migrate/seed (Docker): `docker compose exec backend php artisan migrate --seed`
+- Generate API docs: `docker compose exec backend php artisan l5-swagger:generate`
+- Admin panel: http://localhost:8000/admin
 
-### Linting and Formatting
-
-This project uses several tools to enforce code style and quality.
-
--   **Frontend (TypeScript/React):**
-    -   **ESLint:** For identifying and reporting on patterns in JavaScript. Run with `npm run lint` in the `frontend` directory.
-    -   **Prettier:** An opinionated code formatter. It's recommended to use a Prettier extension in your editor to format on save.
--   **Backend (PHP/Laravel):**
-    -   **PHP-CS-Fixer:** A tool to automatically fix PHP coding standards issues. Run with `composer format` in the `backend` directory.
-    -   **Laravel Pint:** A new, opinionated PHP code style fixer for Laravel projects. It's built on top of PHP-CS-Fixer and is included as a dev dependency.
-        -   To check for style issues, run `./vendor/bin/pint --test` in the `backend` directory.
-        -   To fix style issues, run `./vendor/bin/pint` in the `backend` directory.
-
-### Key Frontend Patterns
-
-- Toasts: `sonner` (`toast`), API client: `@/api/axios` (`api`).
-- Functional components with hooks; permission-driven UI (e.g., `isOwner`).
-
-## 6. Command Glossary
-
--   **Start Application (Docker):** `docker compose up -d --build`
--   **Run Backend Tests:** `docker compose exec backend php artisan test`
--   **Run Frontend Tests:** `cd frontend && npm run test`
--   **Run Migrations/Seeders (Docker):** `docker compose exec backend php artisan migrate --seed`
--   **Generate API Docs:** `docker compose exec backend php artisan l5-swagger:generate`
--   **Admin Panel:** `http://localhost:8000/admin` (Credentials: `test@example.com` / `password`)
-    -   **Helper Profile Moderation:** Approve, reject, suspend, reactivate helper profiles with bulk actions
-    -   **Photo Management:** Upload, edit, and manage helper profile photos via relationship manager
-
-## 7. User Preferences
-
-Development commands: prefer `php artisan ...` locally in `backend/` during dev.
-
-## Agent Quickstart (Read Me First)
-
-This section is for AI coding agents (Copilots) to be effective, safe, and fast in this repo.
-
-### Quick Repo Map
-
-- Backend (Laravel): `backend/` (API, models, policies, Filament admin)
-- Frontend (React+TS): `frontend/` (Vite, shadcn/ui, MSW mocks, Vitest)
-- Docs/ops: `docs/`, `docker-compose.yml`, `GEMINI.md`
-
-### Frontend Rules of the Road
-
-- Axios baseURL `/api`; use relative endpoints (`api.get('pets/1')`) to avoid `/api/api`.
-- MSW tests use absolute URLs; mirror `{ data: ... }` shape.
-- Prefer `findBy...` over nested `waitFor`.
-- Radix/shadcn tests: Select trigger role is `combobox`; provide `DialogDescription`.
-- Stable keys for list items.
-
-### Backend Rules of the Road
-
-- Keep OpenAPI annotations updated; regenerate docs with changes.
-- Enforce policies/permissions; controllers assume policy checks.
-- **Notification Triggers:** The `NotificationService` is the central component for sending notifications. Look for its usage in controllers that handle state changes, such as `TransferRequestController`, to understand what events trigger notifications.
-- Do not read or write `users.role` column; use `$user->hasRole()` / `$user->assignRole()` and `$user->can()`.
-
-### Common Pitfalls & Fixes
-
-- Double `/api` in frontend: use relative endpoints with axios baseURL.
-- Flaky waits: use `findBy...` and stable UI states.
-- MSW shape mismatch: always include top-level `{ data: ... }`.
-- JSDOM gaps: keep setupTests polyfills enabled.
-
-### Typical Agent Workflow
-
-1) Extract requirements into a short checklist; execute if safe.
-2) Find files fast (semantic search); read larger blocks.
-3) Make smallest viable change; preserve public APIs/styles.
-4) If runtime behavior changes, add/adjust tests first/alongside.
-5) Run targeted tests; iterate to green.
-6) Add toasts and refresh hooks for UX/state sync.
-7) Record notable patterns here.
-
-### Patterns Added in This Session (summary)
-
-- Placement responses flow: modal submit → owner confirm/reject with toasts and `refresh()`; `/requests` filters are client-side.
-- Handover lifecycle UI: create pending handover on accept; schedule/modal; status chips; confirm/dispute/cancel/complete; UI hides fulfilled requests.
-- Visibility rule: show "Active Placement Requests" only when open/active.
-- My Pets sections: API returns sections; UI shows sections + "Show all" toggle; keep MSW handlers aligned.
-- Hooks guard: never call hooks conditionally or inline in props; declare `useMemo` at top.
-
-### Session Notes — 2025-08-11 (condensed)
-
-- Vite/ESM type-only imports (`import type { ... }`) to avoid runtime export errors.
-- shadcn/ui: re-export `buttonVariants` from `button.tsx` to avoid missing export issues.
-- Vitest + jsdom: polyfill PointerEvent + pointer capture + `scrollIntoView`; mock `sonner` Toaster; prefer `globalThis` feature checks.
-- ESLint/TS: `??`, await promises, cast before template strings, avoid nested component defs.
-- Radix typing: avoid custom ref props unless needed; prefer simple pass-through or standard `forwardRef`.
-- CatPhotoManager: preserve `viewer_permissions`; compute `canEdit` from owner/permissions; update state + `onPhotoUpdated` after uploads.
-- Axios helper types: use `{ data: T }` generics; destructure `response.data.data`.
-
-### Session Notes — 2025-08-13 (Rehoming/Handover Flow, condensed)
-
-- Endpoints: GET latest handover, POST cancel/confirm/complete routes wired.
-- UI: PetProfile shows chips + meeting details; helper confirm/dispute panel; meeting banner with Cancel/Complete; PetDetails hides fulfilled requests.
-- Policy: `PetPolicy@view` allows accepted helper to view pet until completion.
-- Tests: absolute URLs; `{ data: ... }`; prefer `findBy...`.
-- Follow-ups: post-completion redirects; foster return UI parity.
-
-### Session Notes — 2025-08-16 (Admin & DB Setup, condensed)
-
-- Local DB: default to PostgreSQL for dev; update `.env`; remove redundant migrations; docs added.
-- Admin moderation: HelperProfile actions (approve/reject/suspend/reactivate), bulk actions, suspended status, photo relation manager; badges + confirmations + toasts.
-- Workflow: noted migration conflict resolution; added DB troubleshooting; PostgreSQL recommended for local.
-
-### Speedrun Commands (optional)
-
-```bash
-# Frontend
-cd frontend
-npm test --silent
-
-# Backend
-cd ../backend
-php artisan test
-```
-
-### Session Notes — 2025-09-25 (Placement Request Feature)
-
-- **Backend:**
-  - Added `placement_requests_allowed` boolean to `pet_types` table with a default of `false`.
-  - Updated `PetType` model to include the new field.
-  - Updated `PetTypeSeeder` to set `placement_requests_allowed` to `true` for cats.
-  - Updated `PetCapabilityService` to use the new database field for the `placement` capability.
-  - Created a `helper_profile_pet_type` pivot table to associate helper profiles with pet types.
-  - Updated `HelperProfile` model with a `petTypes` relationship.
-  - Updated `HelperProfileController` to handle the new relationship.
-- **Admin Panel:**
-  - Added a checkbox to the `PetTypeResource` to allow admins to toggle `placement_requests_allowed`.
-- **Frontend:**
-  - Updated the `HelperProfileEditPage` to include a list of checkboxes for pet types that allow placement requests.
-  - Updated the `/requests` page to include a filter for pet types.
-- **Tests:**
-  - Created a `PetTypeFactory`.
-  - Updated `PetCapabilityServiceTest` and `PlacementRequestTest` to reflect the new database-driven `placement` capability.
-  - All tests are passing.
+For complete workflows (Git, CI, more commands), see `docs/development.md`.

--- a/backend/tests/Unit/PetCapabilityServiceTest.php
+++ b/backend/tests/Unit/PetCapabilityServiceTest.php
@@ -18,9 +18,9 @@ class PetCapabilityServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        // Ensure pet types exist (with fixed ids for deterministic tests)
-        PetType::create(['id' => 1, 'name' => 'Cat', 'slug' => 'cat', 'is_system' => true, 'is_active' => true, 'display_order' => 0, 'placement_requests_allowed' => true]);
-        PetType::create(['id' => 2, 'name' => 'Dog', 'slug' => 'dog', 'is_system' => true, 'is_active' => true, 'display_order' => 1]);
+        
+        // Run the PetTypeSeeder to ensure pet types exist with correct capabilities
+        $this->seed(\Database\Seeders\PetTypeSeeder::class);
     }
 
     #[Test]

--- a/docs/development.md
+++ b/docs/development.md
@@ -168,7 +168,8 @@ Requirements
 - PHP 8.4+
 - Composer
 - Node.js 18+
- - Database: Prefer Postgres. SQLite is no longer recommended after schema squashing.
+- PostgreSQL Client Tools (`psql` command)
+- Database: Prefer Postgres. SQLite is no longer recommended after schema squashing.
 
 1) Backend
 ```bash

--- a/utils/dev-pgsql-docker/README.md
+++ b/utils/dev-pgsql-docker/README.md
@@ -4,6 +4,16 @@ This directory contains a Docker Compose setup for running PostgreSQL locally fo
 
 ## Quick Start
 
+### Option A: Automated Setup (Recommended)
+```bash
+cd utils/dev-pgsql-docker
+./fresh-db.sh
+cd ../../backend
+php artisan db:seed
+php artisan serve
+```
+
+### Option B: Manual Setup
 1. **Start the database**:
    ```bash
    cd utils/dev-pgsql-docker
@@ -46,16 +56,22 @@ These settings are already configured in `backend/.env`.
 
 ## PgAdmin Setup
 
-After accessing PgAdmin at http://localhost:8888:
+After accessing PgAdmin at http://localhost:8888 (admin@example.com / admin123):
 
-1. Click "Add New Server"
-2. General tab: Name = "Local Dev"
-3. Connection tab:
-   - Host: `postgres` (Docker Compose service name for internal container communication)
-   - Port: 5432
-   - Database: meo_mai_moi
-   - Username: user
-   - Password: password
+1. **First Login**: Use email `admin@example.com` and password `admin123`
+2. **Add Server Connection**:
+   - Click "Add New Server" or go to Object Explorer → Create → Server
+3. **General Tab**: 
+   - Name: `Local Dev` (or any name you prefer)
+4. **Connection Tab**:
+   - Host name/address: `postgres` (Docker Compose service name for internal container communication)
+   - Port: `5432`
+   - Database: `meo_mai_moi`
+   - Username: `user`
+   - Password: `password`
+5. **Save**: Click "Save" to create the connection
+
+**Important**: Use `postgres` as the host name, not `localhost` or `127.0.0.1`. This is because PgAdmin runs inside a Docker container and needs to connect to the PostgreSQL container using the internal Docker network.
 
 ## Troubleshooting
 

--- a/utils/dev-pgsql-docker/fresh-db.sh
+++ b/utils/dev-pgsql-docker/fresh-db.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Fresh Database Setup Script
+# This script recreates the database and loads the schema for native development
+
+set -e  # Exit on any error
+
+echo "🔄 Setting up fresh database for native development..."
+
+# Check if we're in the right directory
+if [ ! -f "docker-compose.yml" ]; then
+    echo "❌ Error: Run this script from utils/dev-pgsql-docker directory"
+    exit 1
+fi
+
+# Check if containers are running
+if ! docker compose ps | grep -q "Up"; then
+    echo "🚀 Starting PostgreSQL containers..."
+    docker compose up -d
+    echo "⏳ Waiting for database to be ready..."
+    sleep 5
+fi
+
+# Copy schema file into container
+echo "📄 Copying schema file..."
+docker cp ../../backend/database/schema/pgsql-schema.sql postgres_dev:/tmp/schema.sql
+
+# Drop and recreate database
+echo "🗑️  Dropping existing database..."
+docker compose exec postgres dropdb -U user meo_mai_moi 2>/dev/null || echo "Database didn't exist, continuing..."
+
+echo "🆕 Creating fresh database..."
+docker compose exec postgres createdb -U user meo_mai_moi
+
+# Load schema
+echo "📋 Loading schema..."
+docker compose exec postgres psql -U user -d meo_mai_moi -f /tmp/schema.sql > /dev/null
+
+echo "✅ Database setup complete!"
+echo ""
+echo "Next steps:"
+echo "  cd ../../backend"
+echo "  php artisan db:seed"
+echo "  php artisan serve"
+echo ""
+echo "Access points:"
+echo "  • Laravel: http://localhost:8000 (or 8001 if 8000 is busy)"
+echo "  • PgAdmin: http://localhost:8888 (admin@example.com / admin123)"


### PR DESCRIPTION
Refactors GEMINI.md into a concise AI-oriented guide.\n\n- Aligns terminology with docs/development.md and utils/dev-pgsql-docker/README.md\n- Clarifies Postgres-only setup; notes psql requirement for tests\n- Preserves essential testing, debugging, and workflow notes\n\nThis is docs-only.