### PR TITLE
Make API token dialog responsive and wrap long tokens

### DIFF
--- a/frontend/src/pages/settings/ApiTokensSettingsPage.tsx
+++ b/frontend/src/pages/settings/ApiTokensSettingsPage.tsx
@@ -481,7 +481,7 @@ export default function ApiTokensSettingsPage() {
           }
         }}
       >
-        <DialogContent>
+        <DialogContent className="max-w-[calc(100vw-1rem)] sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Token created</DialogTitle>
             <DialogDescription>
@@ -493,7 +493,7 @@ export default function ApiTokensSettingsPage() {
               <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                 {createdTokenName ?? 'API token'}
               </div>
-              <code className="block overflow-x-auto text-xs">{createdPlaintextToken}</code>
+              <code className="block break-all text-xs">{createdPlaintextToken}</code>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row">
               <Button


### PR DESCRIPTION
### Motivation
- Ensure the created API token dialog fits on small screens and that very long tokens wrap instead of causing overflow.

### Description
- Add a responsive max-width to `DialogContent` via `className="max-w-[calc(100vw-1rem)] sm:max-w-md"` to prevent the dialog from exceeding the viewport.
- Replace the `code` element's `overflow-x-auto` with `break-all` so long token strings wrap instead of creating horizontal scroll.

### Testing
- Ran a TypeScript build and the frontend unit tests; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac117f2480832cb1ce68193437db78)